### PR TITLE
Implement AI orchestration service phase 1

### DIFF
--- a/services/ai_orchestration_service/app/api/v1/endpoints/interview.py
+++ b/services/ai_orchestration_service/app/api/v1/endpoints/interview.py
@@ -1,8 +1,16 @@
+"""API endpoints for interview-related operations."""
+
 from fastapi import APIRouter
+
+from app.schemas.interview import InterviewRequest, InterviewResponse
+from app.services.llm_service import generate_next_question
 
 router = APIRouter()
 
-@router.post("/generate-question")
-async def generate_question():
-    """Placeholder endpoint for generating interview questions."""
-    pass
+
+@router.post("/generate-question", response_model=InterviewResponse)
+async def generate_question(request: InterviewRequest) -> InterviewResponse:
+    """Generate the next interview question."""
+
+    question = await generate_next_question(request.context, request.history)
+    return InterviewResponse(question_text=question)

--- a/services/ai_orchestration_service/app/core/config.py
+++ b/services/ai_orchestration_service/app/core/config.py
@@ -1,7 +1,16 @@
 from pydantic import BaseSettings
 
+
 class Settings(BaseSettings):
-    """Application settings."""
+    """Application settings and LLM provider configuration."""
+
+    # Which LLM backend to use: "openai", "gemini", or "local"
+    llm_provider: str = "openai"
+
+    # API keys or URLs for the various providers
     openai_api_key: str = ""
+    gemini_api_key: str = ""
+    local_llm_url: str = "http://localhost:11434/api/generate"
+
 
 settings = Settings()

--- a/services/ai_orchestration_service/app/schemas/interview.py
+++ b/services/ai_orchestration_service/app/schemas/interview.py
@@ -1,9 +1,32 @@
+"""Pydantic models for the interview API."""
+
+from typing import List, Optional
+
 from pydantic import BaseModel
 
+
+class InterviewContext(BaseModel):
+    """Context for the interview such as job description."""
+
+    job_description: str
+    candidate_resume: Optional[str] = None
+
+
+class ConversationTurn(BaseModel):
+    """A single turn in the interview conversation."""
+
+    role: str
+    message: str
+
+
 class InterviewRequest(BaseModel):
-    """Placeholder request model."""
-    pass
+    """Request model for generating the next interview question."""
+
+    context: InterviewContext
+    history: List[ConversationTurn] = []
+
 
 class InterviewResponse(BaseModel):
-    """Placeholder response model."""
-    pass
+    """Response model containing the generated question text."""
+
+    question_text: str

--- a/services/ai_orchestration_service/app/services/llm_service.py
+++ b/services/ai_orchestration_service/app/services/llm_service.py
@@ -1,3 +1,73 @@
-async def generate_next_question(context, history):
-    """Placeholder for LLM interaction."""
-    raise NotImplementedError
+"""Service for interacting with various LLM providers."""
+
+from typing import List
+
+import httpx
+
+from app.core.config import settings
+from app.schemas.interview import ConversationTurn, InterviewContext
+
+
+async def generate_next_question(
+    context: InterviewContext, history: List[ConversationTurn]
+) -> str:
+    """Generate the next interview question using the configured LLM."""
+
+    system_prompt = (
+        "You are an AI technical interviewer. "
+        f"The job description is: {context.job_description}. "
+        "Ask the candidate the next question based on the conversation so far."
+    )
+
+    # Build a plain-text conversation for providers that require it
+    conversation_text = "".join(
+        f"{turn.role}: {turn.message}\n" for turn in history
+    )
+    prompt_text = f"{system_prompt}\n{conversation_text}".strip()
+
+    provider = settings.llm_provider.lower()
+
+    if provider == "openai":
+        messages = [{"role": "system", "content": system_prompt}]
+        for turn in history:
+            messages.append({"role": turn.role, "content": turn.message})
+
+        payload = {"model": "gpt-3.5-turbo", "messages": messages}
+        headers = {"Authorization": f"Bearer {settings.openai_api_key}"}
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return data["choices"][0]["message"]["content"].strip()
+
+    if provider == "gemini":
+        url = (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            "gemini-pro:generateContent"
+            f"?key={settings.gemini_api_key}"
+        )
+        payload = {
+            "contents": [{"parts": [{"text": prompt_text}]}]
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+        return (
+            data["candidates"][0]["content"]["parts"][0]["text"].strip()
+        )
+
+    if provider == "local":
+        payload = {"prompt": prompt_text}
+        async with httpx.AsyncClient() as client:
+            response = await client.post(settings.local_llm_url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+        return data.get("question", "").strip()
+
+    raise ValueError(f"Unsupported LLM provider: {settings.llm_provider}")

--- a/services/ai_orchestration_service/tests/test_interview_api.py
+++ b/services/ai_orchestration_service/tests/test_interview_api.py
@@ -1,0 +1,39 @@
+import httpx
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_generate_question(monkeypatch):
+    async def fake_post(self, url, headers=None, json=None):
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"content": "What is your experience with Python?"}}
+                ]
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    # Ensure the service is using the OpenAI provider for this test
+    settings.llm_provider = "openai"
+
+    payload = {
+        "context": {"job_description": "Backend developer"},
+        "history": [{"role": "candidate", "message": "Hi"}],
+    }
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/interview/generate-question", json=payload
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "question_text": "What is your experience with Python?"
+    }


### PR DESCRIPTION
## Summary
- allow switching between OpenAI, Gemini, and local LLM backends via new configuration options
- route question generation through provider-specific logic based on configured LLM
- adjust unit test to select OpenAI provider during execution

## Testing
- `pip install fastapi httpx uvicorn pytest pytest-asyncio` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `cd services/ai_orchestration_service && pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5055d0308328a8a12963d0f9ead8