### PR TITLE
Add env example and docker-compose setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,21 @@ The platform is built on a modern, scalable backend using a **microservices arch
 * **AI Engine**: The core intelligence is provided by an **`AI Orchestration Service`** that uses a large language model (LLM) to generate questions on the fly. It engineers prompts based on the job description and conversation history to ensure questions are relevant and insightful.
 * **Real-Time Interaction**: An **`Interview Session Service`** manages the candidate experience. It uses **WebSockets** to create a real-time, low-latency chat interface.
 * **Development & Deployment**: The services are containerized using **Docker** and orchestrated for local development with **Docker Compose**, ensuring a consistent and reproducible environment.
+
+## 3. Local Development
+
+Run the services with Docker Compose:
+
+1. Copy the example environment file and provide your own credentials:
+
+   ```bash
+   cp services/ai_orchestration_service/.env.example services/ai_orchestration_service/.env
+   ```
+
+   Update `services/ai_orchestration_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, and `LOCAL_LLM_URL`.
+
+2. Start the containers:
+
+   ```bash
+   docker-compose up --build
+   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./services/ai_orchestration_service/app:/app
     env_file:
-      - ./services/ai_orchestration_service/.env
+      - ./services/ai_orchestration_service/.env  # copy from .env.example and set credentials
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   session_api:
@@ -22,5 +22,5 @@ services:
     volumes:
       - ./services/interview_session_service/app:/app
     env_file:
-      - ./services/interview_session_service/.env
+      - ./services/interview_session_service/.env  # create if environment variables are needed
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload

--- a/services/ai_orchestration_service/.env.example
+++ b/services/ai_orchestration_service/.env.example
@@ -1,0 +1,4 @@
+LLM_PROVIDER=openai
+OPENAI_API_KEY=your-openai-key
+GEMINI_API_KEY=your-gemini-key
+LOCAL_LLM_URL=http://localhost:11434


### PR DESCRIPTION
## Summary
- document docker-based setup and env file usage
- provide `.env.example` for AI orchestration service
- clarify `env_file` expectations in docker-compose

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx; Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5415bb2c832881ba4da462c14c9e