### PR TITLE
Use default factory for interview history

### DIFF
--- a/services/ai_orchestration_service/app/schemas/interview.py
+++ b/services/ai_orchestration_service/app/schemas/interview.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class InterviewContext(BaseModel):
@@ -23,7 +23,7 @@ class InterviewRequest(BaseModel):
     """Request model for generating the next interview question."""
 
     context: InterviewContext
-    history: List[ConversationTurn] = []
+    history: List[ConversationTurn] = Field(default_factory=list)
 
 
 class InterviewResponse(BaseModel):


### PR DESCRIPTION
## Summary
- avoid mutable defaults in InterviewRequest by using `Field(default_factory=list)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56eb6980832888340a6abc40519d