### PR TITLE
Fix FastAPI service module path in Docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,12 @@ services:
       - ./services/ai_orchestration_service/app:/app
     env_file:
       - ./services/ai_orchestration_service/.env  # copy from .env.example and set credentials
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    # The service's application files are mounted directly into /app.
+    # Since main.py lives at the root of that directory, the module
+    # path to the FastAPI instance is simply ``main:app`` rather than
+    # ``app.main:app``. Using ``app.main`` caused a ModuleNotFoundError
+    # because Python looked for ``/app/app`` which does not exist.
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 
   session_api:
     build:
@@ -21,4 +26,5 @@ services:
       - ./services/interview_session_service/app:/app
     env_file:
       - ./services/interview_session_service/.env  # create if environment variables are needed
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    # See note above regarding module import paths within the container.
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload

--- a/services/ai_orchestration_service/Dockerfile
+++ b/services/ai_orchestration_service/Dockerfile
@@ -3,4 +3,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app /app
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Application code is copied directly into /app, so the FastAPI instance
+# lives in main.py at the root of the working directory. The previous
+# command attempted to import ``app.main`` which looked for /app/app
+# and failed with ``ModuleNotFoundError``. Import ``main:app`` instead.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/interview_session_service/Dockerfile
+++ b/services/interview_session_service/Dockerfile
@@ -3,4 +3,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app /app
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Like the AI orchestration service, the source files are placed directly
+# in /app, so the FastAPI application resides in main.py. Referencing
+# ``app.main`` results in a missing module error. Import ``main:app``
+# to start the server correctly.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- correct `uvicorn` command in docker-compose and both service Dockerfiles
- add comments explaining why `main:app` is required to avoid missing `app` module

## Testing
- `PYTHONPATH=services/ai_orchestration_service pytest services/ai_orchestration_service/tests/test_interview_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab69c740e08328b6d699d5019a643b