### PR TITLE
refactor: use package-relative imports

### DIFF
--- a/services/ai_orchestration_service/app/api/v1/endpoints/interview.py
+++ b/services/ai_orchestration_service/app/api/v1/endpoints/interview.py
@@ -2,8 +2,8 @@
 
 from fastapi import APIRouter
 
-from app.schemas.interview import InterviewRequest, InterviewResponse
-from app.services.llm_service import generate_next_question
+from schemas.interview import InterviewRequest, InterviewResponse
+from services.llm_service import generate_next_question
 
 router = APIRouter()
 

--- a/services/ai_orchestration_service/app/api/v1/router.py
+++ b/services/ai_orchestration_service/app/api/v1/router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import interview
+from .endpoints import interview
 
 api_router = APIRouter()
 api_router.include_router(interview.router, prefix="/interview", tags=["interview"])

--- a/services/ai_orchestration_service/app/main.py
+++ b/services/ai_orchestration_service/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.router import api_router
+from api.v1.router import api_router
 
 app = FastAPI(title="AI Orchestration Service")
 app.include_router(api_router, prefix="/api/v1")

--- a/services/ai_orchestration_service/app/services/llm_service.py
+++ b/services/ai_orchestration_service/app/services/llm_service.py
@@ -4,8 +4,8 @@ from typing import List
 
 import httpx
 
-from app.core.config import settings
-from app.schemas.interview import ConversationTurn, InterviewContext
+from core.config import settings
+from schemas.interview import ConversationTurn, InterviewContext
 
 
 async def generate_next_question(

--- a/services/ai_orchestration_service/tests/test_interview_api.py
+++ b/services/ai_orchestration_service/tests/test_interview_api.py
@@ -1,9 +1,14 @@
+import sys
+from pathlib import Path
+
 import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.core.config import settings
-from app.main import app
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from core.config import settings
+from main import app
 
 
 @pytest.mark.asyncio

--- a/services/interview_session_service/app/main.py
+++ b/services/interview_session_service/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import interview_ws
+from api.v1.endpoints import interview_ws
 
 app = FastAPI(title="Interview Session Service")
 app.include_router(interview_ws.router, prefix="/api/v1")


### PR DESCRIPTION
## Summary
- use package-relative imports across app modules
- adjust tests to include app package path

## Testing
- `pytest services/ai_orchestration_service/tests/test_interview_api.py -q`
- `pytest -q`


------