### PR TITLE
Add configurable timeout for LLM HTTP requests

### DIFF
--- a/services/ai_orchestration_service/app/core/config.py
+++ b/services/ai_orchestration_service/app/core/config.py
@@ -12,5 +12,8 @@ class Settings(BaseSettings):
     gemini_api_key: str = ""
     local_llm_url: str = "http://localhost:11434/api/generate"
 
+    # Timeout (in seconds) for outgoing HTTP requests to LLM providers
+    llm_timeout: float = 10.0
+
 
 settings = Settings()

--- a/services/ai_orchestration_service/app/services/llm_service.py
+++ b/services/ai_orchestration_service/app/services/llm_service.py
@@ -35,7 +35,7 @@ async def generate_next_question(
         payload = {"model": "gpt-3.5-turbo", "messages": messages}
         headers = {"Authorization": f"Bearer {settings.openai_api_key}"}
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:
             response = await client.post(
                 "https://api.openai.com/v1/chat/completions",
                 headers=headers,
@@ -54,7 +54,7 @@ async def generate_next_question(
         payload = {
             "contents": [{"parts": [{"text": prompt_text}]}]
         }
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:
             response = await client.post(url, json=payload)
             response.raise_for_status()
             data = response.json()
@@ -64,7 +64,7 @@ async def generate_next_question(
 
     if provider == "local":
         payload = {"prompt": prompt_text}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:
             response = await client.post(settings.local_llm_url, json=payload)
             response.raise_for_status()
             data = response.json()

--- a/services/ai_orchestration_service/tests/test_llm_timeout.py
+++ b/services/ai_orchestration_service/tests/test_llm_timeout.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from core.config import settings
+from schemas.interview import InterviewContext, ConversationTurn
+from services.llm_service import generate_next_question
+
+
+@pytest.mark.asyncio
+async def test_generate_next_question_uses_configured_timeout(monkeypatch):
+    settings.llm_provider = "openai"
+    settings.llm_timeout = 7.5
+
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, headers=None, json=None):
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Example?"}}]},
+                request=httpx.Request("POST", url),
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    await generate_next_question(
+        InterviewContext(job_description="Backend developer"),
+        [ConversationTurn(role="candidate", message="Hi")],
+    )
+
+    assert captured["timeout"] == settings.llm_timeout


### PR DESCRIPTION
## Summary
- make LLM HTTP timeout configurable via settings
- apply timeout when creating httpx.AsyncClient
- test that the configured timeout is used during request generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab710058d08328806c78186d48dd15