### PR TITLE
feat: make OpenAI model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run the services with Docker Compose:
    cp services/ai_orchestration_service/.env.example services/ai_orchestration_service/.env
    ```
 
-   Update `services/ai_orchestration_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, and `LOCAL_LLM_URL`.
+    Update `services/ai_orchestration_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_MODEL`, `GEMINI_API_KEY`, and `LOCAL_LLM_URL`.
 
 2. Start the containers:
 

--- a/services/ai_orchestration_service/.env.example
+++ b/services/ai_orchestration_service/.env.example
@@ -1,4 +1,5 @@
 LLM_PROVIDER=openai
 OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-3.5-turbo
 GEMINI_API_KEY=your-gemini-key
 LOCAL_LLM_URL=http://localhost:11434

--- a/services/ai_orchestration_service/app/core/config.py
+++ b/services/ai_orchestration_service/app/core/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
 
     # API keys or URLs for the various providers
     openai_api_key: str = ""
+    # Default OpenAI model to use
+    openai_model: str = "gpt-3.5-turbo"
     gemini_api_key: str = ""
     local_llm_url: str = "http://localhost:11434/api/generate"
 

--- a/services/ai_orchestration_service/app/services/llm_service.py
+++ b/services/ai_orchestration_service/app/services/llm_service.py
@@ -32,7 +32,7 @@ async def generate_next_question(
         for turn in history:
             messages.append({"role": turn.role, "content": turn.message})
 
-        payload = {"model": "gpt-3.5-turbo", "messages": messages}
+        payload = {"model": settings.openai_model, "messages": messages}
         headers = {"Authorization": f"Bearer {settings.openai_api_key}"}
 
         async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:


### PR DESCRIPTION
## Summary
- add `openai_model` configuration with a default value
- use `settings.openai_model` in LLM service
- document `OPENAI_MODEL` in environment setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7228e84c83288ac37cc642d6565e