### PR TITLE
Use pyproject for service dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   ai_orchestration_api:
     build:
-      context: ./services/ai_orchestration_service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/ai_orchestration_service/Dockerfile
     ports:
       - "8001:8000"
     volumes:
@@ -18,8 +18,8 @@ services:
 
   session_api:
     build:
-      context: ./services/interview_session_service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/interview_session_service/Dockerfile
     ports:
       - "8002:8000"
     volumes:

--- a/services/ai_orchestration_service/Dockerfile
+++ b/services/ai_orchestration_service/Dockerfile
@@ -1,8 +1,20 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
+
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-COPY app /app
+
+# Install Python dependencies defined in the repository's pyproject.toml
+COPY pyproject.toml /tmp/pyproject.toml
+RUN python - <<'PY'
+import tomllib, pathlib
+deps = tomllib.load(open('/tmp/pyproject.toml', 'rb'))['project']['dependencies']
+pathlib.Path('/tmp/requirements.txt').write_text('\n'.join(deps))
+PY
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt /tmp/pyproject.toml
+
+# Copy the service application code into the image
+COPY services/ai_orchestration_service/app /app
+
 # Application code is copied directly into /app, so the FastAPI instance
 # lives in main.py at the root of the working directory. The previous
 # command attempted to import ``app.main`` which looked for /app/app

--- a/services/ai_orchestration_service/requirements.txt
+++ b/services/ai_orchestration_service/requirements.txt
@@ -1,3 +1,0 @@
-fastapi
-uvicorn[standard]
-httpx

--- a/services/interview_session_service/Dockerfile
+++ b/services/interview_session_service/Dockerfile
@@ -1,8 +1,20 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
+
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-COPY app /app
+
+# Install Python dependencies defined in the repository's pyproject.toml
+COPY pyproject.toml /tmp/pyproject.toml
+RUN python - <<'PY'
+import tomllib, pathlib
+deps = tomllib.load(open('/tmp/pyproject.toml', 'rb'))['project']['dependencies']
+pathlib.Path('/tmp/requirements.txt').write_text('\n'.join(deps))
+PY
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt /tmp/pyproject.toml
+
+# Copy the service application code into the image
+COPY services/interview_session_service/app /app
+
 # Like the AI orchestration service, the source files are placed directly
 # in /app, so the FastAPI application resides in main.py. Referencing
 # ``app.main`` results in a missing module error. Import ``main:app``

--- a/services/interview_session_service/requirements.txt
+++ b/services/interview_session_service/requirements.txt
@@ -1,3 +1,0 @@
-fastapi
-uvicorn[standard]
-httpx


### PR DESCRIPTION
## Summary
- install dependencies in service images from pyproject.toml
- update services to Python 3.12 and drop requirements.txt files
- adjust docker-compose build contexts to repository root

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7503ce908328bf460783b89c4e33