### PR TITLE
Use host.docker.internal for local LLM access

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ Run the services with Docker Compose:
    cp services/ai_orchestration_service/.env.example services/ai_orchestration_service/.env
    ```
 
-    Update `services/ai_orchestration_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_MODEL`, `GEMINI_API_KEY`, and `LOCAL_LLM_URL`.
+   Update `services/ai_orchestration_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_MODEL`, `GEMINI_API_KEY`, and `LOCAL_LLM_URL`.
+
+   When using an LLM running on your host machine (e.g., LM Studio), set
+   `LLM_PROVIDER=local` and point `LOCAL_LLM_URL` to the host using
+   `host.docker.internal`. For example:
+
+   ```bash
+   LOCAL_LLM_URL=http://host.docker.internal:1234/v1/chat/completions
+   ```
 
 2. Start the containers:
 

--- a/services/ai_orchestration_service/.env.example
+++ b/services/ai_orchestration_service/.env.example
@@ -1,5 +1,8 @@
-LLM_PROVIDER=openai
-OPENAI_API_KEY=your-openai-key
+LLM_PROVIDER=local
+# Optional: leave these blank or provide keys if switching providers
+OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo
-GEMINI_API_KEY=your-gemini-key
-LOCAL_LLM_URL=http://localhost:11434
+GEMINI_API_KEY=
+# When running LM Studio on the host machine, containers must use
+# host.docker.internal to reach it.
+LOCAL_LLM_URL=http://host.docker.internal:1234/v1/chat/completions

--- a/services/ai_orchestration_service/app/core/config.py
+++ b/services/ai_orchestration_service/app/core/config.py
@@ -13,10 +13,9 @@ class Settings(BaseSettings):
     # Default OpenAI model to use
     openai_model: str = "gpt-3.5-turbo"
     gemini_api_key: str = ""
-    # Change localhost to host.docker.internal to allow the container to
-    # connect to a service running on the host machine.
-    # local_llm_url: str = "http://192.168.0.127:1234/v1/chat/completions"
-    local_llm_url:str = "http://host.docker.internal:1234/v1/chat/completions"
+    # Default endpoint for a locally hosted model.
+    # `host.docker.internal` lets containers reach services on the host.
+    local_llm_url: str = "http://host.docker.internal:1234/v1/chat/completions"
 
     # Timeout (in seconds) for outgoing HTTP requests to LLM providers
     llm_timeout: float = 10.0

--- a/services/ai_orchestration_service/pyproject.toml
+++ b/services/ai_orchestration_service/pyproject.toml
@@ -23,5 +23,8 @@ llm_provider = "local"
 openai_api_key = ""
 openai_model = "gpt-3.5-turbo"
 gemini_api_key = ""
-local_llm_url = "http://host.docker.internal:1234/v1/completions"
+# Default URL for a locally hosted LLM like LM Studio.
+# `host.docker.internal` allows Docker containers to access services
+# running on the host machine.
+local_llm_url = "http://host.docker.internal:1234/v1/chat/completions"
 llm_timeout = 10.0


### PR DESCRIPTION
## Summary
- Point local LLM configs to `host.docker.internal` so containers can reach models running on the host
- Document host usage in README and sample env file

## Testing
- `pytest services/ai_orchestration_service/tests/test_interview_api.py::test_generate_question -q` (fails: fake_post() got an unexpected keyword argument 'content')


------
https://chatgpt.com/codex/tasks/task_e_68ab96ee39788328aa01ba367f944cb2