### PR TITLE
Add test frontend and session WebSocket handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,22 @@ Run the services with Docker Compose:
    ```bash
    docker-compose up --build
    ```
+
+## 4. Test Frontend & End-to-End Testing
+
+Once the backend services are running, you can drive a sample interview using the lightweight test frontend located in `test_frontend/`.
+
+1. Start the services if they are not already running:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+2. In a new terminal, serve the static files:
+
+   ```bash
+   python -m http.server --directory test_frontend 3000
+   ```
+
+3. Open [http://localhost:3000](http://localhost:3000) in your browser. The page connects to the WebSocket service and lets you exchange messages with the AI interviewer.
+

--- a/services/ai_orchestration_service/app/services/llm_service.py
+++ b/services/ai_orchestration_service/app/services/llm_service.py
@@ -1,17 +1,12 @@
-# In services/ai_orchestration_service/app/services/llm_service.py
+"""Service for interacting with various LLM providers."""
 
-"""Service for interacting with various LLM providers."""
-"""Service for interacting with various LLM providers."""
-import logging
 from typing import List
-import json
+
 import httpx
 
 from core.config import settings
 from schemas.interview import ConversationTurn, InterviewContext
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO)
 
 async def generate_next_question(
     context: InterviewContext, history: List[ConversationTurn]
@@ -24,47 +19,28 @@ async def generate_next_question(
         "Ask the candidate the next question based on the conversation so far."
     )
 
-    provider = "local" # settings.llm_provider.lower()
+    provider = settings.llm_provider.lower()
 
-    if provider == "local":
-        messages = [{"role": "system", "content": system_prompt}]
-        for turn in history:
-            role = "user" if turn.role == "candidate" else "assistant"
-            messages.append({"role": role, "content": turn.message})
+    messages = [{"role": "system", "content": system_prompt}]
+    for turn in history:
+        role = "user" if turn.role == "candidate" else "assistant"
+        messages.append({"role": role, "content": turn.message})
 
-        payload = {
-            "model": "google/gemma-3-1b",
-            "messages": messages,
-            "stream": False
-        }
-        
-        # --- Logging the Raw Request Details ---
-        url =  "https://248e110186a5.ngrok-free.app/v1/chat/completions"# settings.local_llm_url
-        headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
-        body = json.dumps(payload, indent=2)
+    if provider == "openai":
+        payload = {"model": settings.openai_model, "messages": messages}
+        headers = {"Authorization": f"Bearer {settings.openai_api_key}"}
+        url = "https://api.openai.com/v1/chat/completions"
+    elif provider == "local":
+        payload = {"model": "google/gemma-3-1b", "messages": messages, "stream": False}
+        headers = {"Content-Type": "application/json"}
+        url = settings.local_llm_url
+    else:
+        raise ValueError(f"Unsupported LLM provider: {settings.llm_provider}")
 
-        logging.info("--- Preparing to send request ---")
-        logging.info(f"METHOD: POST")
-        logging.info(f"URL: {url}")
-        logging.info(f"HEADERS:\n{json.dumps(headers, indent=2)}")
-        logging.info(f"BODY:\n{body}")
-        logging.info("---------------------------------")
-        # ----------------------------------------
-        
-        try:
-            async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:
-                # Using the manually prepared headers and content
-                response = await client.post(url, headers=headers, content=body)
-                response.raise_for_status()
-                data = response.json()
-            
-            return data["choices"][0]["message"]["content"].strip()
-        except httpx.ConnectError as e:
-            logging.error(f"CONNECTION FAILED: Could not connect to {url}. Please ensure the server is running, accessible from Docker, and not blocked by a firewall.")
-            raise e # Re-raise the exception after logging
-        except Exception as e:
-            logging.error(f"An unexpected error occurred: {e}")
-            raise e
+    async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:
+        response = await client.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+        data = response.json()
 
+    return data["choices"][0]["message"]["content"].strip()
 
-    raise ValueError(f"Unsupported LLM provider: {settings.llm_provider}")

--- a/services/interview_session_service/app/api/v1/endpoints/interview_ws.py
+++ b/services/interview_session_service/app/api/v1/endpoints/interview_ws.py
@@ -1,9 +1,23 @@
-from fastapi import APIRouter, WebSocket
+"""WebSocket endpoint for interview sessions."""
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from services.connection_manager import ConnectionManager
+
 
 router = APIRouter()
+manager = ConnectionManager()
+
 
 @router.websocket("/ws/{interview_id}")
-async def websocket_endpoint(websocket: WebSocket, interview_id: str):
-    """Placeholder WebSocket endpoint."""
-    await websocket.accept()
-    await websocket.close()
+async def websocket_endpoint(websocket: WebSocket, interview_id: str) -> None:
+    """Handle a WebSocket connection for a given interview."""
+
+    await manager.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_json()
+            await manager.handle_message(websocket, data)
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
+

--- a/services/interview_session_service/app/services/connection_manager.py
+++ b/services/interview_session_service/app/services/connection_manager.py
@@ -1,4 +1,62 @@
+"""Manage interview WebSocket sessions."""
+
+import os
+from typing import Dict, List
+
+import httpx
+from fastapi import WebSocket
+
+
+AI_API_URL = os.getenv(
+    "AI_ORCHESTRATION_URL", "http://localhost:8001/api/v1/interview"
+)
+
+
 class ConnectionManager:
-    """Placeholder connection manager."""
-    async def handle_message(self, websocket, data):
-        pass
+    """Minimal connection manager for interview sessions."""
+
+    def __init__(self) -> None:
+        self.history: Dict[WebSocket, List[dict]] = {}
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.history[websocket] = []
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self.history.pop(websocket, None)
+
+    async def handle_message(self, websocket: WebSocket, data: dict) -> None:
+        """Process an incoming message from the client."""
+
+        conversation = self.history.setdefault(websocket, [])
+        event = data.get("event")
+
+        if event == "join_session":
+            await websocket.send_json({"event": "session_started"})
+            question = await self._next_question(conversation)
+            conversation.append({"role": "interviewer", "message": question})
+            await websocket.send_json(
+                {"event": "new_question", "payload": {"question_text": question}}
+            )
+
+        elif event == "send_answer":
+            answer = data.get("payload", {}).get("answer_text", "")
+            conversation.append({"role": "candidate", "message": answer})
+            await websocket.send_json({"event": "interviewer_typing"})
+            question = await self._next_question(conversation)
+            conversation.append({"role": "interviewer", "message": question})
+            await websocket.send_json(
+                {"event": "new_question", "payload": {"question_text": question}}
+            )
+
+    async def _next_question(self, history: List[dict]) -> str:
+        payload = {
+            "context": {"job_description": "Backend developer"},
+            "history": history,
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{AI_API_URL}/generate-question", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+        return data["question_text"]
+

--- a/test_frontend/app.js
+++ b/test_frontend/app.js
@@ -1,0 +1,61 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const chatLog = document.getElementById('chat-log');
+    const chatInput = document.getElementById('chat-input');
+    const sendButton = document.getElementById('send-button');
+    const statusIndicator = document.getElementById('status-indicator');
+
+    const socket = new WebSocket('ws://localhost:8002/ws/test-interview-123');
+
+    function addMessage(sender, text) {
+        const message = document.createElement('div');
+        message.classList.add('message', sender);
+        message.textContent = text;
+        chatLog.appendChild(message);
+        chatLog.scrollTop = chatLog.scrollHeight;
+    }
+
+    socket.onopen = () => {
+        statusIndicator.textContent = 'Connected. Waiting for interview to start...';
+        socket.send(JSON.stringify({ event: 'join_session', payload: { interview_id: 'test-interview-123' } }));
+    };
+
+    socket.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        statusIndicator.textContent = 'Connected';
+        switch (data.event) {
+            case 'session_started':
+                chatInput.disabled = false;
+                sendButton.disabled = false;
+                break;
+            case 'new_question':
+                addMessage('interviewer', data.payload.question_text);
+                break;
+            case 'interviewer_typing':
+                statusIndicator.textContent = 'AI is thinking...';
+                break;
+            case 'session_ended':
+                addMessage('interviewer', data.payload.message);
+                chatInput.disabled = true;
+                sendButton.disabled = true;
+                break;
+        }
+    };
+
+    socket.onclose = () => {
+        statusIndicator.textContent = 'Connection closed.';
+        chatInput.disabled = true;
+        sendButton.disabled = true;
+    };
+
+    function sendMessage() {
+        const messageText = chatInput.value;
+        if (messageText.trim() !== '') {
+            addMessage('candidate', messageText);
+            socket.send(JSON.stringify({ event: 'send_answer', payload: { answer_text: messageText } }));
+            chatInput.value = '';
+        }
+    }
+
+    sendButton.addEventListener('click', sendMessage);
+    chatInput.addEventListener('keypress', (e) => e.key === 'Enter' && sendMessage());
+});

--- a/test_frontend/index.html
+++ b/test_frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Interview Test Client</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="chat-container">
+        <div id="chat-log"></div>
+        <div id="status-indicator">Connecting...</div>
+        <div id="input-container">
+            <input type="text" id="chat-input" placeholder="Type your answer here..." disabled>
+            <button id="send-button" disabled>Send</button>
+        </div>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/test_frontend/style.css
+++ b/test_frontend/style.css
@@ -1,0 +1,11 @@
+body { font-family: sans-serif; background-color: #f0f2f5; }
+#chat-container { max-width: 600px; margin: 30px auto; border: 1px solid #ccc; background: #fff; }
+#chat-log { height: 400px; overflow-y: scroll; padding: 10px; border-bottom: 1px solid #ccc; }
+.message { padding: 8px 12px; margin: 5px; border-radius: 18px; max-width: 75%; }
+.interviewer { background-color: #e4e6eb; text-align: left; }
+.candidate { background-color: #0084ff; color: white; text-align: right; margin-left: auto; }
+#status-indicator { padding: 5px 10px; font-size: 0.8em; color: #888; }
+#input-container { display: flex; padding: 10px; }
+#chat-input { flex-grow: 1; border: 1px solid #ccc; border-radius: 18px; padding: 10px; }
+#send-button { margin-left: 10px; padding: 10px 15px; border: none; background: #0084ff; color: white; border-radius: 18px; cursor: pointer; }
+#send-button:disabled { background: #999; }


### PR DESCRIPTION
## Summary
- implement WebSocket connection manager to drive interview sessions and fetch questions from AI service
- expose `/ws/{interview_id}` endpoint using the connection manager
- refactor LLM service to support configurable providers and JSON-based requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba3de9a38832892d913b55d915738