### PR TITLE
chore: externalize config

### DIFF
--- a/services/ai_orchestration_service/.env
+++ b/services/ai_orchestration_service/.env
@@ -1,0 +1,6 @@
+LLM_PROVIDER=local
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-3.5-turbo
+GEMINI_API_KEY=
+LOCAL_LLM_URL=https://248e110186a5.ngrok-free.app/v1/chat/completions
+LLM_TIMEOUT=10.0

--- a/services/ai_orchestration_service/.env.example
+++ b/services/ai_orchestration_service/.env.example
@@ -6,3 +6,4 @@ GEMINI_API_KEY=
 # When running LM Studio on the host machine, containers must use
 # host.docker.internal to reach it.
 LOCAL_LLM_URL=http://host.docker.internal:1234/v1/chat/completions
+LLM_TIMEOUT=10.0

--- a/services/ai_orchestration_service/app/core/config.py
+++ b/services/ai_orchestration_service/app/core/config.py
@@ -1,25 +1,32 @@
 # In services/ai_orchestration_service/app/core/config.py
-from pydantic_settings import BaseSettings
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application settings and LLM provider configuration."""
 
+    model_config = SettingsConfigDict(
+        env_file=Path(__file__).resolve().parents[2] / ".env",
+        env_file_encoding="utf-8",
+    )
+
     # Which LLM backend to use: "openai", "gemini", or "local"
-    llm_provider: str = "local"
+    llm_provider: str
 
     # API keys or URLs for the various providers
-    openai_api_key: str = ""
+    openai_api_key: str
     # Default OpenAI model to use
-    openai_model: str = "gpt-3.5-turbo"
-    gemini_api_key: str = ""
+    openai_model: str
+    gemini_api_key: str
     # Default endpoint for a locally hosted model.
     # `host.docker.internal` lets containers reach services on the host.
     # local_llm_url: str = "http://host.docker.internal:1234/v1/chat/completions"
-    local_llm_url: str = "https://248e110186a5.ngrok-free.app/v1/chat/completions"
+    local_llm_url: str
 
     # Timeout (in seconds) for outgoing HTTP requests to LLM providers
-    llm_timeout: float = 10.0
+    llm_timeout: float
 
 
 settings = Settings()

--- a/services/interview_session_service/.env
+++ b/services/interview_session_service/.env
@@ -1,0 +1,1 @@
+AI_ORCHESTRATION_URL=http://localhost:8001/api/v1/interview

--- a/services/interview_session_service/app/services/connection_manager.py
+++ b/services/interview_session_service/app/services/connection_manager.py
@@ -7,9 +7,7 @@ import httpx
 from fastapi import WebSocket
 
 
-AI_API_URL = os.getenv(
-    "AI_ORCHESTRATION_URL", "http://localhost:8001/api/v1/interview"
-)
+AI_API_URL = os.getenv("AI_ORCHESTRATION_URL")
 
 
 class ConnectionManager:


### PR DESCRIPTION
## Summary
- load orchestration service settings from a `.env` file
- pull AI service URL from environment in session manager
- add example timeout setting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba9fd4c2c83288b645faab532f5fb