### PR TITLE
Add front-end interview setup and topic analysis

### DIFF
--- a/services/ai_orchestration_service/app/api/v1/endpoints/interview.py
+++ b/services/ai_orchestration_service/app/api/v1/endpoints/interview.py
@@ -2,8 +2,14 @@
 
 from fastapi import APIRouter
 
-from schemas.interview import InterviewRequest, InterviewResponse
+from schemas.interview import (
+    InterviewRequest,
+    InterviewResponse,
+    InterviewContext,
+    TopicsResponse,
+)
 from services.llm_service import generate_next_question
+from services.topic_service import determine_topics
 
 router = APIRouter()
 
@@ -14,3 +20,11 @@ async def generate_question(request: InterviewRequest) -> InterviewResponse:
 
     question = await generate_next_question(request.context, request.history)
     return InterviewResponse(question_text=question)
+
+
+@router.post("/determine-topics", response_model=TopicsResponse)
+async def determine_topics_endpoint(context: InterviewContext) -> TopicsResponse:
+    """Determine interview topics based on job description and resume."""
+
+    topics = await determine_topics(context)
+    return TopicsResponse(topics=topics)

--- a/services/ai_orchestration_service/app/schemas/interview.py
+++ b/services/ai_orchestration_service/app/schemas/interview.py
@@ -30,3 +30,9 @@ class InterviewResponse(BaseModel):
     """Response model containing the generated question text."""
 
     question_text: str
+
+
+class TopicsResponse(BaseModel):
+    """Response model containing inferred interview topics."""
+
+    topics: List[str]

--- a/services/ai_orchestration_service/app/services/topic_service.py
+++ b/services/ai_orchestration_service/app/services/topic_service.py
@@ -1,0 +1,18 @@
+"""Topic inference service for interview preparation."""
+from typing import List
+
+from schemas.interview import InterviewContext
+
+
+async def determine_topics(context: InterviewContext) -> List[str]:
+    """Infer interview topics from job description and resume.
+
+    This is a placeholder implementation that extracts simple keyword-based
+    topics. A real implementation would call an LLM to perform deeper
+    analysis.
+    """
+
+    text = f"{context.job_description} {context.candidate_resume or ''}".lower()
+    keywords = ["python", "javascript", "java", "frontend", "backend", "database"]
+    topics = [word for word in keywords if word in text]
+    return topics or ["general"]

--- a/services/ai_orchestration_service/tests/test_interview_api.py
+++ b/services/ai_orchestration_service/tests/test_interview_api.py
@@ -49,3 +49,21 @@ async def test_generate_question(monkeypatch):
     assert response.json() == {
         "question_text": "What is your experience with Python?"
     }
+
+
+@pytest.mark.asyncio
+async def test_determine_topics():
+    payload = {
+        "job_description": "Looking for Python developer",
+        "candidate_resume": "Experience with databases",
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post(
+            "/api/v1/interview/determine-topics", json=payload
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"topics": ["python", "database"]}

--- a/services/interview_session_service/app/services/connection_manager.py
+++ b/services/interview_session_service/app/services/connection_manager.py
@@ -15,6 +15,7 @@ class ConnectionManager:
 
     def __init__(self) -> None:
         self.history: Dict[WebSocket, List[dict]] = {}
+        self.contexts: Dict[WebSocket, dict] = {}
 
     async def connect(self, websocket: WebSocket) -> None:
         await websocket.accept()
@@ -22,6 +23,7 @@ class ConnectionManager:
 
     def disconnect(self, websocket: WebSocket) -> None:
         self.history.pop(websocket, None)
+        self.contexts.pop(websocket, None)
 
     async def handle_message(self, websocket: WebSocket, data: dict) -> None:
         """Process an incoming message from the client."""
@@ -30,8 +32,16 @@ class ConnectionManager:
         event = data.get("event")
 
         if event == "join_session":
+            payload = data.get("payload", {})
+            context = {
+                "job_description": payload.get("job_description", ""),
+                "candidate_resume": payload.get("candidate_resume", ""),
+            }
+            self.contexts[websocket] = context
+            topics = await self._determine_topics(context)
             await websocket.send_json({"event": "session_started"})
-            question = await self._next_question(conversation)
+            await websocket.send_json({"event": "topics", "payload": {"topics": topics}})
+            question = await self._next_question(websocket, conversation)
             conversation.append({"role": "interviewer", "message": question})
             await websocket.send_json(
                 {"event": "new_question", "payload": {"question_text": question}}
@@ -41,20 +51,24 @@ class ConnectionManager:
             answer = data.get("payload", {}).get("answer_text", "")
             conversation.append({"role": "candidate", "message": answer})
             await websocket.send_json({"event": "interviewer_typing"})
-            question = await self._next_question(conversation)
+            question = await self._next_question(websocket, conversation)
             conversation.append({"role": "interviewer", "message": question})
             await websocket.send_json(
                 {"event": "new_question", "payload": {"question_text": question}}
             )
 
-    async def _next_question(self, history: List[dict]) -> str:
-        payload = {
-            "context": {"job_description": "Backend developer"},
-            "history": history,
-        }
+    async def _next_question(self, websocket: WebSocket, history: List[dict]) -> str:
+        context = self.contexts.get(websocket, {"job_description": ""})
+        payload = {"context": context, "history": history}
         async with httpx.AsyncClient() as client:
             resp = await client.post(f"{AI_API_URL}/generate-question", json=payload)
             resp.raise_for_status()
             data = resp.json()
         return data["question_text"]
+
+    async def _determine_topics(self, context: dict) -> None:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{AI_API_URL}/determine-topics", json=context)
+            resp.raise_for_status()
+            return resp.json().get("topics", [])
 

--- a/services/interview_session_service/tests/test_interview_ws.py
+++ b/services/interview_session_service/tests/test_interview_ws.py
@@ -31,11 +31,11 @@ def patch_ai_url(monkeypatch):
 
 
 class DummyResponse:
-    def __init__(self, question):
-        self.question = question
+    def __init__(self, data):
+        self._data = data
 
     def json(self):
-        return {"question_text": self.question}
+        return self._data
 
     def raise_for_status(self):
         pass
@@ -44,19 +44,30 @@ class DummyResponse:
 @pytest.mark.asyncio
 async def test_join_session_sends_first_question(monkeypatch):
     async def fake_post(self, url, json=None):
+        if url.endswith("/determine-topics"):
+            return DummyResponse({"topics": ["python"]})
         assert url == "http://ai/interview/generate-question"
-        return DummyResponse("First question?")
+        return DummyResponse({"question_text": "First question?"})
 
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
 
     with TestClient(session_app) as client:
         with client.websocket_connect("/api/v1/ws/test") as websocket:
-            websocket.send_json({"event": "join_session", "payload": {"interview_id": "test"}})
+            websocket.send_json({
+                "event": "join_session",
+                "payload": {
+                    "interview_id": "test",
+                    "job_description": "Backend dev",
+                    "candidate_resume": "Experienced in Python",
+                },
+            })
             data1 = websocket.receive_json()
             data2 = websocket.receive_json()
+            data3 = websocket.receive_json()
 
     assert data1 == {"event": "session_started"}
-    assert data2 == {"event": "new_question", "payload": {"question_text": "First question?"}}
+    assert data2 == {"event": "topics", "payload": {"topics": ["python"]}}
+    assert data3 == {"event": "new_question", "payload": {"question_text": "First question?"}}
 
 
 @pytest.mark.asyncio
@@ -64,14 +75,24 @@ async def test_send_answer_triggers_followup(monkeypatch):
     questions = iter(["First question?", "Second question?"])
 
     async def fake_post(self, url, json=None):
-        return DummyResponse(next(questions))
+        if url.endswith("/determine-topics"):
+            return DummyResponse({"topics": ["python"]})
+        return DummyResponse({"question_text": next(questions)})
 
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
 
     with TestClient(session_app) as client:
         with client.websocket_connect("/api/v1/ws/test") as websocket:
-            websocket.send_json({"event": "join_session", "payload": {"interview_id": "test"}})
+            websocket.send_json({
+                "event": "join_session",
+                "payload": {
+                    "interview_id": "test",
+                    "job_description": "Backend dev",
+                    "candidate_resume": "Experienced in Python",
+                },
+            })
             websocket.receive_json()  # session_started
+            websocket.receive_json()  # topics
             websocket.receive_json()  # first question
 
             websocket.send_json({"event": "send_answer", "payload": {"answer_text": "hi"}})

--- a/test_frontend/chat.html
+++ b/test_frontend/chat.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Interview Test Client</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="chat-container">
+        <div id="chat-log"></div>
+        <div id="status-indicator">Connecting...</div>
+        <div id="input-container">
+            <input type="text" id="chat-input" placeholder="Type your answer here..." disabled>
+            <button id="send-button" disabled>Send</button>
+        </div>
+    </div>
+    <script src="chat.js"></script>
+</body>
+</html>

--- a/test_frontend/chat.js
+++ b/test_frontend/chat.js
@@ -5,6 +5,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const statusIndicator = document.getElementById('status-indicator');
 
     const socket = new WebSocket('ws://localhost:8002/ws/test-interview-123');
+    const jobDescription = sessionStorage.getItem('job_description') || '';
+    const resume = sessionStorage.getItem('candidate_resume') || '';
 
     function addMessage(sender, text) {
         const message = document.createElement('div');
@@ -16,7 +18,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
     socket.onopen = () => {
         statusIndicator.textContent = 'Connected. Waiting for interview to start...';
-        socket.send(JSON.stringify({ event: 'join_session', payload: { interview_id: 'test-interview-123' } }));
+        socket.send(
+            JSON.stringify({
+                event: 'join_session',
+                payload: {
+                    interview_id: 'test-interview-123',
+                    job_description: jobDescription,
+                    candidate_resume: resume,
+                },
+            })
+        );
     };
 
     socket.onmessage = (event) => {
@@ -26,6 +37,9 @@ document.addEventListener("DOMContentLoaded", () => {
             case 'session_started':
                 chatInput.disabled = false;
                 sendButton.disabled = false;
+                break;
+            case 'topics':
+                addMessage('interviewer', 'Topics: ' + data.payload.topics.join(', '));
                 break;
             case 'new_question':
                 addMessage('interviewer', data.payload.question_text);

--- a/test_frontend/index.html
+++ b/test_frontend/index.html
@@ -2,18 +2,23 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Interview Test Client</title>
+    <title>Start Interview</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="chat-container">
-        <div id="chat-log"></div>
-        <div id="status-indicator">Connecting...</div>
-        <div id="input-container">
-            <input type="text" id="chat-input" placeholder="Type your answer here..." disabled>
-            <button id="send-button" disabled>Send</button>
-        </div>
+    <div id="form-container">
+        <textarea id="job-description" placeholder="Job description"></textarea>
+        <textarea id="resume" placeholder="Paste your resume here"></textarea>
+        <button id="start-button">Start Interview</button>
     </div>
-    <script src="app.js"></script>
+    <script>
+    document.getElementById('start-button').addEventListener('click', () => {
+        const jd = document.getElementById('job-description').value;
+        const resume = document.getElementById('resume').value;
+        sessionStorage.setItem('job_description', jd);
+        sessionStorage.setItem('candidate_resume', resume);
+        window.location.href = 'chat.html';
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Collect job description and resume on a new landing page and forward them to the chat interface
- WebSocket session now infers topics and starts interviews with provided context
- AI orchestration exposes a `determine-topics` endpoint with a basic keyword-based implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb2a9990c83289a36dd77737a0b91