### PR TITLE
Polish test chat UI with Bootstrap

### DIFF
--- a/test_frontend/chat.html
+++ b/test_frontend/chat.html
@@ -3,17 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <title>Interview Test Client</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="chat-container">
-        <div id="chat-log"></div>
-        <div id="status-indicator">Connecting...</div>
-        <div id="input-container">
-            <input type="text" id="chat-input" placeholder="Type your answer here..." disabled>
-            <button id="send-button" disabled>Send</button>
+    <div class="container my-4">
+        <div class="card">
+            <div id="chat-log" class="card-body overflow-auto" style="height: 400px;"></div>
+            <div class="card-footer">
+                <div id="status-indicator" class="small text-muted mb-2">Connecting...</div>
+                <div class="input-group">
+                    <input type="text" id="chat-input" class="form-control" placeholder="Type your answer here..." disabled>
+                    <button id="send-button" class="btn btn-primary" disabled>Send</button>
+                </div>
+            </div>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="chat.js"></script>
 </body>
 </html>

--- a/test_frontend/chat.js
+++ b/test_frontend/chat.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
     function addMessage(sender, text) {
         const message = document.createElement('div');
         message.classList.add('message', sender);
-        message.textContent = text;
+        message.innerHTML = marked.parse(text);
         chatLog.appendChild(message);
         chatLog.scrollTop = chatLog.scrollHeight;
     }
@@ -45,12 +45,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 addMessage('interviewer', data.payload.question_text);
                 break;
             case 'interviewer_typing':
-                statusIndicator.textContent = 'AI is thinking...';
+                statusIndicator.innerHTML = '<div class="spinner-border spinner-border-sm me-2" role="status"></div>AI is thinking...';
                 break;
             case 'session_ended':
                 addMessage('interviewer', data.payload.message);
                 chatInput.disabled = true;
                 sendButton.disabled = true;
+                statusIndicator.textContent = 'Interview ended';
                 break;
         }
     };

--- a/test_frontend/index.html
+++ b/test_frontend/index.html
@@ -3,20 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <title>Start Interview</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="form-container">
+    <div class="container py-5">
+        <div class="card p-4 mx-auto" style="max-width: 600px;">
+            <select id="prefill-select" class="form-select mb-3">
+                <option value="">-- Select sample data --</option>
+                <option value="frontend">Frontend Developer</option>
+                <option value="data">Data Scientist</option>
+            </select>
 
-        <select id="prefill-select">
-            <option value="">-- Select sample data --</option>
-            <option value="frontend">Frontend Developer</option>
-            <option value="data">Data Scientist</option>
-        </select>
-
-        <textarea id="job-description" placeholder="Job description"></textarea>
-        <textarea id="resume" placeholder="Paste your resume here"></textarea>
-        <button id="start-button">Start Interview</button>
+            <textarea id="job-description" class="form-control mb-3" placeholder="Job description"></textarea>
+            <textarea id="resume" class="form-control mb-3" placeholder="Paste your resume here"></textarea>
+            <button id="start-button" class="btn btn-primary w-100">Start Interview</button>
+        </div>
     </div>
     <script>
 
@@ -47,5 +49,6 @@
         window.location.href = 'chat.html';
     });
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/test_frontend/style.css
+++ b/test_frontend/style.css
@@ -1,11 +1,23 @@
-body { font-family: sans-serif; background-color: #f0f2f5; }
-#chat-container { max-width: 600px; margin: 30px auto; border: 1px solid #ccc; background: #fff; }
-#chat-log { height: 400px; overflow-y: scroll; padding: 10px; border-bottom: 1px solid #ccc; }
-.message { padding: 8px 12px; margin: 5px; border-radius: 18px; max-width: 75%; }
-.interviewer { background-color: #e4e6eb; text-align: left; }
-.candidate { background-color: #0084ff; color: white; text-align: right; margin-left: auto; }
-#status-indicator { padding: 5px 10px; font-size: 0.8em; color: #888; }
-#input-container { display: flex; padding: 10px; }
-#chat-input { flex-grow: 1; border: 1px solid #ccc; border-radius: 18px; padding: 10px; }
-#send-button { margin-left: 10px; padding: 10px 15px; border: none; background: #0084ff; color: white; border-radius: 18px; cursor: pointer; }
-#send-button:disabled { background: #999; }
+body { background-color: #f0f2f5; }
+
+#chat-log { height: 400px; overflow-y: auto; }
+
+.message {
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
+  border-radius: 1rem;
+  max-width: 75%;
+}
+
+.interviewer {
+  background-color: #e9ecef;
+  text-align: left;
+}
+
+.candidate {
+  background-color: #0d6efd;
+  color: white;
+  text-align: right;
+  margin-left: auto;
+}
+


### PR DESCRIPTION
## Summary
- style index and chat pages with Bootstrap for a more polished look
- render chat messages as Markdown and show spinner while interviewer is typing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abba59fcf48328832eca8481d5a77e