### PR TITLE
feat: add option for direct service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Run the services with Docker Compose:
    docker-compose up --build
    ```
 
+### Direct service calls
+
+By default the Interview Session Service reaches the AI Orchestration Service over
+HTTP. To call the orchestration logic directly without making HTTP requests, set
+`AI_ORCHESTRATION_USE_DIRECT=true` in `services/interview_session_service/.env`.
+This allows the services to invoke each other's methods in-process. If the
+orchestration package is not available, the session service logs a warning and
+falls back to HTTP.
+
 ## 4. Test Frontend & End-to-End Testing
 
 Once the backend services are running, you can drive a sample interview using the lightweight test frontend located in `test_frontend/`.

--- a/services/interview_session_service/.env
+++ b/services/interview_session_service/.env
@@ -1,1 +1,2 @@
 AI_ORCHESTRATION_URL=http://localhost:8001/api/v1/interview
+AI_ORCHESTRATION_USE_DIRECT=false

--- a/services/interview_session_service/app/services/connection_manager.py
+++ b/services/interview_session_service/app/services/connection_manager.py
@@ -1,13 +1,37 @@
 """Manage interview WebSocket sessions."""
 
 import os
+import logging
 from typing import Dict, List
 
 import httpx
 from fastapi import WebSocket
 
 
+logger = logging.getLogger(__name__)
+
 AI_API_URL = os.getenv("AI_ORCHESTRATION_URL")
+USE_DIRECT = os.getenv("AI_ORCHESTRATION_USE_DIRECT", "false").lower() == "true"
+
+if USE_DIRECT:
+    try:
+        from services.ai_orchestration_service.app.schemas.interview import (
+            ConversationTurn,
+            InterviewContext,
+        )
+        from services.ai_orchestration_service.app.services.llm_service import (
+            generate_next_question as direct_generate_question,
+        )
+        from services.ai_orchestration_service.app.services.topic_service import (
+            determine_topics as direct_determine_topics,
+        )
+    except ModuleNotFoundError as exc:
+        logger.warning(
+            "AI_ORCHESTRATION_USE_DIRECT set but AI orchestration package not found; "
+            "falling back to HTTP. Error: %s",
+            exc,
+        )
+        USE_DIRECT = False
 
 
 class ConnectionManager:
@@ -59,6 +83,10 @@ class ConnectionManager:
 
     async def _next_question(self, websocket: WebSocket, history: List[dict]) -> str:
         context = self.contexts.get(websocket, {"job_description": ""})
+        if USE_DIRECT:
+            interview_context = InterviewContext(**context)
+            turns = [ConversationTurn(**t) for t in history]
+            return await direct_generate_question(interview_context, turns)
         payload = {"context": context, "history": history}
         async with httpx.AsyncClient() as client:
             resp = await client.post(f"{AI_API_URL}/generate-question", json=payload)
@@ -66,7 +94,10 @@ class ConnectionManager:
             data = resp.json()
         return data["question_text"]
 
-    async def _determine_topics(self, context: dict) -> None:
+    async def _determine_topics(self, context: dict) -> List[str]:
+        if USE_DIRECT:
+            interview_context = InterviewContext(**context)
+            return await direct_determine_topics(interview_context)
         async with httpx.AsyncClient() as client:
             resp = await client.post(f"{AI_API_URL}/determine-topics", json=context)
             resp.raise_for_status()


### PR DESCRIPTION
## Summary
- allow interview session service to invoke AI orchestration methods directly without HTTP when AI_ORCHESTRATION_USE_DIRECT=true
- document direct call option and example env var
- gracefully fall back to HTTP when direct orchestration package not found

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbc38b25483288454ab7be862e528