### PR TITLE
Expose app packages in session service image

### DIFF
--- a/services/interview_session_service/Dockerfile
+++ b/services/interview_session_service/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12-slim
 
 WORKDIR /app
+ENV PYTHONPATH=/app:/app/..
 
 # Install Python dependencies defined for this service
 


### PR DESCRIPTION
## Summary
- add `PYTHONPATH` to session service Dockerfile so the app and its parent are on the module path

## Testing
- `pytest`
- `docker compose build session_api` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68abc0a524dc8328b5672d96eb881710