### PR TITLE
Fix direct orchestration imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Run the services with Docker Compose:
 
 By default the Interview Session Service reaches the AI Orchestration Service over
 HTTP. To call the orchestration logic directly without making HTTP requests, set
-`AI_ORCHESTRATION_USE_DIRECT=true` in `services/interview_session_service/.env`.
+`AI_ORCHESTRATION_USE_DIRECT=true` in `services/interview_session_service/.env`
+**only when both containers share a PYTHONPATH that includes the repository
+root** so the `ai_orchestration_service` package can be imported directly.
 
 This allows the services to invoke each other's methods in-process. If the
 orchestration package is not available, the session service logs a warning and

--- a/services/interview_session_service/.env
+++ b/services/interview_session_service/.env
@@ -1,2 +1,3 @@
 AI_ORCHESTRATION_URL=http://localhost:8001/api/v1/interview
+# Enable direct imports only when containers share a PYTHONPATH that includes the repo
 AI_ORCHESTRATION_USE_DIRECT=false

--- a/services/interview_session_service/app/services/connection_manager.py
+++ b/services/interview_session_service/app/services/connection_manager.py
@@ -16,14 +16,14 @@ USE_DIRECT = os.getenv("AI_ORCHESTRATION_USE_DIRECT", "false").lower() == "true"
 if USE_DIRECT:
 
     try:
-        from services.ai_orchestration_service.app.schemas.interview import (
+        from ai_orchestration_service.app.schemas.interview import (
             ConversationTurn,
             InterviewContext,
         )
-        from services.ai_orchestration_service.app.services.llm_service import (
+        from ai_orchestration_service.app.services.llm_service import (
             generate_next_question as direct_generate_question,
         )
-        from services.ai_orchestration_service.app.services.topic_service import (
+        from ai_orchestration_service.app.services.topic_service import (
             determine_topics as direct_determine_topics,
         )
     except ModuleNotFoundError as exc:


### PR DESCRIPTION
## Summary
- remove `services.` prefix from direct AI orchestration imports
- document that `AI_ORCHESTRATION_USE_DIRECT` requires shared `PYTHONPATH`
- comment `.env` to clarify when to enable direct orchestration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc1af48c88328a3ca57b8d34ccfb8