### PR TITLE
Enable verbose network logging and fix WebSocket path

### DIFF
--- a/services/interview_session_service/app/services/connection_manager.py
+++ b/services/interview_session_service/app/services/connection_manager.py
@@ -53,6 +53,7 @@ class ConnectionManager:
     async def handle_message(self, websocket: WebSocket, data: dict) -> None:
         """Process an incoming message from the client."""
 
+        logger.info("Received message: %s", data)
         conversation = self.history.setdefault(websocket, [])
         event = data.get("event")
 
@@ -87,20 +88,31 @@ class ConnectionManager:
         if USE_DIRECT:
             interview_context = InterviewContext(**context)
             turns = [ConversationTurn(**t) for t in history]
-            return await direct_generate_question(interview_context, turns)
+            question = await direct_generate_question(interview_context, turns)
+            logger.info("Direct generate_question response: %s", question)
+            return question
         payload = {"context": context, "history": history}
+        logger.info("POST %s/generate-question payload=%s", AI_API_URL, payload)
         async with httpx.AsyncClient() as client:
             resp = await client.post(f"{AI_API_URL}/generate-question", json=payload)
+            logger.info("Response status %s", getattr(resp, "status_code", "unknown"))
             resp.raise_for_status()
             data = resp.json()
+        logger.info("Response body: %s", data)
         return data["question_text"]
 
     async def _determine_topics(self, context: dict) -> List[str]:
         if USE_DIRECT:
             interview_context = InterviewContext(**context)
-            return await direct_determine_topics(interview_context)
+            topics = await direct_determine_topics(interview_context)
+            logger.info("Direct determine_topics response: %s", topics)
+            return topics
+        logger.info("POST %s/determine-topics payload=%s", AI_API_URL, context)
         async with httpx.AsyncClient() as client:
             resp = await client.post(f"{AI_API_URL}/determine-topics", json=context)
+            logger.info("Response status %s", getattr(resp, "status_code", "unknown"))
             resp.raise_for_status()
-            return resp.json().get("topics", [])
+            data = resp.json()
+        logger.info("Response body: %s", data)
+        return data.get("topics", [])
 

--- a/test_frontend/chat.js
+++ b/test_frontend/chat.js
@@ -4,7 +4,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const sendButton = document.getElementById('send-button');
     const statusIndicator = document.getElementById('status-indicator');
 
-    const socket = new WebSocket('ws://localhost:8002/ws/test-interview-123');
+    const wsUrl = 'ws://localhost:8002/api/v1/ws/test-interview-123';
+    console.log('Connecting to WebSocket:', wsUrl);
+    const socket = new WebSocket(wsUrl);
     const jobDescription = sessionStorage.getItem('job_description') || '';
     const resume = sessionStorage.getItem('candidate_resume') || '';
 
@@ -18,19 +20,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
     socket.onopen = () => {
         statusIndicator.textContent = 'Connected. Waiting for interview to start...';
-        socket.send(
-            JSON.stringify({
-                event: 'join_session',
-                payload: {
-                    interview_id: 'test-interview-123',
-                    job_description: jobDescription,
-                    candidate_resume: resume,
-                },
-            })
-        );
+        const joinPayload = {
+            event: 'join_session',
+            payload: {
+                interview_id: 'test-interview-123',
+                job_description: jobDescription,
+                candidate_resume: resume,
+            },
+        };
+        console.log('>>', joinPayload);
+        socket.send(JSON.stringify(joinPayload));
     };
 
     socket.onmessage = (event) => {
+        console.log('<<', event.data);
         const data = JSON.parse(event.data);
         statusIndicator.textContent = 'Connected';
         switch (data.event) {
@@ -56,17 +59,23 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     };
 
-    socket.onclose = () => {
+    socket.onclose = (event) => {
+        console.log('WebSocket closed:', event);
         statusIndicator.textContent = 'Connection closed.';
         chatInput.disabled = true;
         sendButton.disabled = true;
+    };
+    socket.onerror = (event) => {
+        console.error('WebSocket error:', event);
     };
 
     function sendMessage() {
         const messageText = chatInput.value;
         if (messageText.trim() !== '') {
             addMessage('candidate', messageText);
-            socket.send(JSON.stringify({ event: 'send_answer', payload: { answer_text: messageText } }));
+            const messagePayload = { event: 'send_answer', payload: { answer_text: messageText } };
+            console.log('>>', messagePayload);
+            socket.send(JSON.stringify(messagePayload));
             chatInput.value = '';
         }
     }


### PR DESCRIPTION
## Summary
- Add detailed request/response logging to the session service connection manager
- Fix WebSocket path and add verbose message logging in test frontend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb7e705e0832891e74bd13a895ab1