### PR TITLE
Handle missing scheme for local LLM URL

### DIFF
--- a/services/interview_services/ai_interview_service.py
+++ b/services/interview_services/ai_interview_service.py
@@ -33,6 +33,10 @@ async def generate_next_question(
         payload = {"model": "google/gemma-3-1b", "messages": messages, "stream": False}
         headers = {"Content-Type": "application/json"}
         url = settings.local_llm_url
+        if not url:
+            raise ValueError("local_llm_url must be configured for local LLM provider")
+        if not url.startswith(("http://", "https://")):
+            url = f"http://{url}"
     else:
         raise ValueError(f"Unsupported LLM provider: {settings.llm_provider}")
 

--- a/services/interview_services/tests/test_ai_interview_service.py
+++ b/services/interview_services/tests/test_ai_interview_service.py
@@ -83,3 +83,28 @@ async def test_generate_next_question_uses_configured_timeout(monkeypatch):
     )
 
     assert captured["timeout"] == settings.llm_timeout
+
+
+@pytest.mark.asyncio
+async def test_local_llm_url_defaults_to_http(monkeypatch):
+    captured = {}
+
+    async def fake_post(self, url, headers=None, json=None):
+        captured["url"] = url
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "Hi"}}]},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(settings, "llm_provider", "local")
+    monkeypatch.setattr(settings, "local_llm_url", "localhost:9999/v1/chat/completions")
+
+    question = await ai.generate_next_question(
+        InterviewContext(job_description="Backend developer"),
+        [],
+    )
+
+    assert question == "Hi"
+    assert captured["url"] == "http://localhost:9999/v1/chat/completions"


### PR DESCRIPTION
## Summary
- validate local LLM URL and add `http://` when scheme is missing
- raise a clear error when local LLM URL isn't configured
- test local provider URL normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac031327fc83288d4915963afd2ef6