### PR TITLE
Improve local LLM error handling

### DIFF
--- a/services/interview_services/ai_interview_service.py
+++ b/services/interview_services/ai_interview_service.py
@@ -33,12 +33,22 @@ async def generate_next_question(
         payload = {"model": "google/gemma-3-1b", "messages": messages, "stream": False}
         headers = {"Content-Type": "application/json"}
         url = settings.local_llm_url
+        if not url:
+            raise ValueError("local_llm_url must be configured for local LLM provider")
+        if not url.startswith(("http://", "https://")):
+            url = f"http://{url}"
     else:
         raise ValueError(f"Unsupported LLM provider: {settings.llm_provider}")
 
     async with httpx.AsyncClient(timeout=settings.llm_timeout) as client:
         response = await client.post(url, headers=headers, json=payload)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = exc.response.text.strip()
+            raise RuntimeError(
+                f"LLM provider request failed: {exc.response.status_code} {detail}"
+            ) from exc
         data = response.json()
 
     return data["choices"][0]["message"]["content"].strip()

--- a/services/interview_services/tests/test_ai_interview_service.py
+++ b/services/interview_services/tests/test_ai_interview_service.py
@@ -83,3 +83,61 @@ async def test_generate_next_question_uses_configured_timeout(monkeypatch):
     )
 
     assert captured["timeout"] == settings.llm_timeout
+
+
+@pytest.mark.asyncio
+async def test_local_llm_url_defaults_to_http(monkeypatch):
+    captured = {}
+
+    async def fake_post(self, url, headers=None, json=None):
+        captured["url"] = url
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "Hi"}}]},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(settings, "llm_provider", "local")
+    monkeypatch.setattr(settings, "local_llm_url", "localhost:9999/v1/chat/completions")
+
+    question = await ai.generate_next_question(
+        InterviewContext(job_description="Backend developer"),
+        [],
+    )
+
+    assert question == "Hi"
+    assert captured["url"] == "http://localhost:9999/v1/chat/completions"
+
+
+@pytest.mark.asyncio
+async def test_missing_local_llm_url_raises_error(monkeypatch):
+    monkeypatch.setattr(settings, "llm_provider", "local")
+    monkeypatch.setattr(settings, "local_llm_url", "")
+
+    with pytest.raises(ValueError, match="local_llm_url must be configured"):
+        await ai.generate_next_question(
+            InterviewContext(job_description="Backend"),
+            [],
+        )
+
+
+@pytest.mark.asyncio
+async def test_http_error_raises_runtime_error(monkeypatch):
+    monkeypatch.setattr(settings, "llm_provider", "local")
+    monkeypatch.setattr(settings, "local_llm_url", "http://localhost")
+
+    async def fake_post(self, url, headers=None, json=None):
+        return httpx.Response(
+            400,
+            text="bad request",
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="LLM provider request failed: 400"):
+        await ai.generate_next_question(
+            InterviewContext(job_description="Backend"),
+            [],
+        )


### PR DESCRIPTION
## Summary
- raise a descriptive runtime error when the local LLM request fails
- cover missing `local_llm_url` and HTTP error scenarios with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac031327fc83288d4915963afd2ef6