### PR TITLE
Add blueprint and application flow documentation

### DIFF
--- a/application-flow.md
+++ b/application-flow.md
@@ -1,0 +1,85 @@
+# Application Flow
+
+This document describes the end-to-end flow of the AI interview application, detailing how each service is initiated and interacts during a session.
+
+## 1. Service Startup
+1. **FastAPI application** (`services/ai_orchestration_service/app/main.py`)
+    - Creates `FastAPI` instance.
+    - Adds CORS middleware.
+    - Registers REST endpoints for question generation, blueprint creation, answer evaluation, sample data, sessions, and report downloads.
+    - On `startup`, seeds the sample SQLite database.
+
+2. **WebSocket Connection Manager** (`services/ai_orchestration_service/session_service/service.py`)
+    - Instantiated in `main.py` as `ws_manager`.
+    - Manages session state, history, timers, and communication over WebSocket.
+
+3. **AI Gateway** (`services/ai_orchestration_service/ai_gateway.py`)
+    - Initializes on import; loads model routing config.
+    - Exposes `gateway.execute_task` for LLM interactions used by orchestration functions.
+
+## 2. Session Initiation
+1. **Client handshake**
+    - Frontend (`test_frontend/chat.js`) opens WebSocket to `/api/v1/ws/{session_id}`.
+    - On `open`, client emits `join_session` with job description, resume, persona, and optional limits.
+
+2. **Connection Manager.connect**
+    - Accepts connection, initializes session dictionaries, associates session ID.
+
+3. **Blueprint Generation**
+    - `handle_message` receives `join_session`.
+    - Calls `create_interview_blueprint` → `ai_orchestration.create_interview_blueprint` → `gateway.execute_task` to obtain structured topics.
+    - Session record created in SQLite via `create_session`.
+
+4. **Initial Question**
+    - State engine (`InterviewState`) selects first topic.
+    - `_next_question` generates introductory question or soft skill question using `generate_introductory_question` / `generate_soft_skill_question`.
+    - Sends `session_started`, `blueprint`, and `new_question` events to client.
+
+## 3. Question–Answer Loop
+1. **Candidate responds**
+    - Client emits `send_answer` with text.
+
+2. **Evaluation**
+    - `_evaluate_answer` builds `EvaluationRequest` with last question and topic blueprint.
+    - `ai_orchestration.evaluate_candidate_answer` invokes `gateway.execute_task` to produce score, depth, confidence, truthfulness.
+    - Results logged to session DB via `log_turn`; `evaluation` event sent back.
+
+3. **State Update**
+    - `InterviewState.update_state_after_answer` adjusts difficulty and topic mastery.
+    - If topic complete, `get_next_topic` selects next one.
+    - Phase advances (`introduction` → `soft_skills` → `technical`) as required.
+
+4. **Next Question**
+    - `_next_question` composes follow-up:
+        - Builds `InterviewRequest` with context, conversation history, topic, difficulty.
+        - `ai_orchestration.generate_next_question` calls `gateway.execute_task`.
+        - Prefaces question with randomized feedback string.
+    - `new_question` event sent to client.
+
+5. **Skip Question**
+    - Client may send `skip_question`.
+    - Manager logs skipped turn, advances phase/topic, calls `_next_question` to deliver another `new_question`.
+
+## 4. Limits and Termination
+1. **Limit Enforcement**
+    - `_limits_exceeded` checks elapsed time and word count before/after each answer.
+    - If exceeded, `_force_end` records session and closes socket.
+
+2. **End Interview**
+    - Client sends `end_interview` or limits trigger forced end.
+    - `generate_final_summary` aggregates `performance_log` for final score and summary via LLM.
+    - `end_session` persists final rubric, transcript, duration, word count, summary.
+    - Sends `interview_ended` event and closes connection.
+
+## 5. Post-Interview Retrieval
+1. **REST Endpoints** (`main.py`)
+    - `/api/v1/sessions` lists stored sessions.
+    - `/api/v1/sessions/{id}` retrieves session metadata and conversation turns.
+    - `/api/v1/sessions/{id}/report` generates PDF using `report.generate_report_pdf`.
+
+2. **Sample Data Endpoints**
+    - `/samples` and `/samples/{key}` expose seeded example prompts for testing.
+
+---
+
+This flow reflects the full lifecycle from service startup through session management, LLM-powered question/evaluation, and reporting.

--- a/code-change-blue-print.md
+++ b/code-change-blue-print.md
@@ -1,0 +1,110 @@
+# Code Change Blueprint: AI Interviewer Alignment
+
+## Step 1 – Introduce Orchestrator Service
+- **File**: `services/orchestrator_service/orchestrator.py`
+  - `class Orchestrator`
+    - `run_session(session_ctx)` – own timer, topic coverage, and log dispatch.
+    - `decide_next_action(state)` – choose ask / probe / switch topic / wrap.
+    - `record_turn(turn)` – persist transcript and metadata.
+- **File**: `services/orchestrator_service/__init__.py`
+  - Export `Orchestrator` for other services.
+
+## Step 2 – Refactor WebSocket ConnectionManager
+- **File**: `services/ai_orchestration_service/session_service/service.py`
+  - `ConnectionManager` delegates agenda & pacing to `Orchestrator` methods.
+  - Replace inline question selection with orchestrator callbacks.
+  - Expose hook `on_turn_complete(result)` for Monitor/Scoring modules.
+
+## Step 3 – Create LLM Interviewer Module
+- **File**: `services/interviewer_service/interviewer.py`
+  - `class LLMInterviewer`
+    - `next_question(context, item)` – paraphrase bank item and add micro‑empathy.
+    - `warm_start(resume)` – rapport & diagnostic.
+    - `wrap_up(state)` – final summary question.
+- **File**: `services/interviewer_service/__init__.py`
+
+## Step 4 – Create LLM Monitor Module
+- **File**: `services/monitor_service/monitor.py`
+  - `class LLMMonitor`
+    - `assess_turn(state, question, answer)` – clarity, relevance, est_difficulty.
+    - `suggest_next(state)` – recommended skill + level.
+    - `time_nudge(state)` – enforce timebox, detect drift or hallucination.
+- **File**: `services/monitor_service/__init__.py`
+
+## Step 5 – Implement Scoring Engine
+- **File**: `services/scoring_service/scoring_engine.py`
+  - `class ScoringEngine`
+    - `aggregate(result, tests, rubric)` – fuse signals, compute sub‑scores.
+    - `finalize(performance_log)` – produce final score & justification.
+- **File**: `services/scoring_service/__init__.py`
+
+## Step 6 – Build Question Bank & Generator
+- **File**: `services/question_service/question_bank.py`
+  - `load_items()` – load seed bank with skill tags & tests.
+  - `pick_item(state, monitor_diag)` – select next item via info gain & coverage.
+- **File**: `services/question_service/generator.py`
+  - `paraphrase(item, style)` – natural phrasing while preserving tags/tests.
+- **File**: `services/question_service/__init__.py`
+
+## Step 7 – Provide Execution Sandboxes
+- **File**: `services/sandbox_service/code_runner.py`
+  - `run_code(language, snippet, tests)` – exec with timeouts and resource caps.
+- **File**: `services/sandbox_service/sql_runner.py`
+  - `run_query(schema, data, query)` – isolated SQL evaluation.
+- **File**: `services/sandbox_service/__init__.py`
+
+## Step 8 – Implement Evidence Store
+- **File**: `services/evidence_service/resume_parser.py`
+  - `parse_resume(text)` – build claims graph nodes & edges.
+- **File**: `services/evidence_service/artifact_ingest.py`
+  - `ingest_repo(url)` – optional GitHub/portfolio ingestion.
+- **File**: `services/evidence_service/__init__.py`
+
+## Step 9 – Centralize Storage & Audit
+- **File**: `services/storage_service/storage.py`
+  - `save_transcript(session_id, turns)` – encrypted log storage.
+  - `save_decision(state)` – persist prompts, model IDs, scoring decisions.
+- **File**: `services/storage_service/__init__.py`
+
+## Step 10 – Adaptivity & Difficulty Engine
+- **File**: `services/adaptivity_service/ability_model.py`
+  - `update(skill, response, time_taken)` – Bayesian/IRT posterior update.
+  - `recommend_next()` – item selection signals for Question Bank.
+- **File**: `services/adaptivity_service/__init__.py`
+
+## Step 11 – Resume Claim Verification
+- **File**: `services/verification_service/prober.py`
+  - `select_claim(state)` – choose resume claim to probe.
+  - `generate_probe(claim)` – specific, counterfactual, or micro‑task probe.
+- **File**: `services/verification_service/__init__.py`
+
+## Step 12 – Evaluation Pipeline Hooks
+- **File**: `services/ai_orchestration_service/ai_orchestration.py`
+  - Add orchestrator hooks `on_question_selected`, `on_answer_scored` to call Interviewer, Monitor, Scoring Engine.
+- **File**: `services/ai_orchestration_service/app/main.py`
+  - Expose REST/WebSocket routes that broker requests across new services.
+
+## Step 13 – Question Quality Analytics
+- **File**: `services/analytics_service/item_metrics.py`
+  - `update_stats(item_id, score, time)` – difficulty & discrimination updates.
+  - `record_feedback(item_id, clarity_rating)` – capture candidate feedback.
+- **File**: `services/analytics_service/__init__.py`
+
+## Step 14 – Safety, Fairness, Privacy Guardrails
+- **File**: `services/guardrails_service/filters.py`
+  - `check_question(text)` – block protected attributes / offensive tone.
+  - `anonymize_logs(turn)` – remove PII before storage.
+- **File**: `services/guardrails_service/__init__.py`
+
+## Step 15 – Orchestration Loop Integration
+- **File**: `services/orchestrator_service/orchestrator.py`
+  - Add `loop()` implementing pseudocode: monitor → bank → interviewer → tools → scoring.
+- **File**: `services/ai_orchestration_service/session_service/service.py`
+  - Replace internal loop with call to `Orchestrator.loop()` for each session.
+
+## Step 16 – Performance & Modularity Notes
+- Adopt async I/O in all service methods to maximize concurrency.
+- Use dependency injection to swap LLM providers or sandboxes.
+- Cache question bank & model prompts to reduce latency.
+- Separate services enable horizontal scaling via containers or workers.
+


### PR DESCRIPTION
## Summary
- Add `code-change-blue-print.md` detailing step-by-step plan to align the project with a modular AI interviewer design
- Add `application-flow.md` outlining how services initialize, communicate, and terminate during an interview session

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6ced744c83289bf32571dd9e732b