### PR TITLE
Add candidate profile generation and pass profile to auto-answer

### DIFF
--- a/services/api_service/app/main.py
+++ b/services/api_service/app/main.py
@@ -130,6 +130,9 @@ async def auto_answer(session_id: str, payload: dict):
     - confidence_level: float in [0,1]
     - job_description: optional str
     - candidate_resume: optional str
+    - candidate_profile: optional str
+    - candidate_id: optional str
+    - job_id: optional int
     Returns: {"answer_text": str}
     """
     try:
@@ -139,6 +142,9 @@ async def auto_answer(session_id: str, payload: dict):
             float(payload.get("confidence_level", 0.7)),
             job_description=payload.get("job_description"),
             candidate_resume=payload.get("candidate_resume"),
+            candidate_profile=payload.get("candidate_profile"),
+            candidate_id=payload.get("candidate_id"),
+            job_id=payload.get("job_id"),
         )
     except ValueError as e:
         # session not found or no question

--- a/services/app_test_service/service.py
+++ b/services/app_test_service/service.py
@@ -8,42 +8,114 @@ Includes utilities for:
 from __future__ import annotations
 
 import uuid
-from typing import Dict, List, Optional
+import json
+from typing import Any, Dict, List, Optional
 
 from gateway_service import gateway
 from sample_data_service import sample_data_repo as samples
 from session_service.database import get_session as db_get_session, get_conversation_turns as db_get_turns
 
 
-async def generate_candidate_for_job(job_id: int) -> Dict[str, str]:
-    """Create a fake candidate resume for the given job posting.
-
-    Uses the default LLM via the gateway to craft a realistic resume based
-    on the job description. The generated resume is stored in the
-    `candidate_resumes` table and returned to the caller.
-    """
+async def generate_candidate_for_job(job_id: int) -> Dict[str, Any]:
+    """Create a fake candidate profile and resume for the given job posting."""
     posting = samples.get_job_posting(job_id)
     if not posting:
         raise ValueError("Job not found")
 
-    system_prompt = (
-        "You are to invent a realistic job candidate. Given the following job "
-        "posting, craft a concise resume paragraph summarizing the candidate's "
-        "relevant experience. Respond ONLY with a JSON object containing a "
-        "'resume' field.\n\n"
-        f"Job Title: {posting['job_title']}\n"
-        f"Description: {posting['description']}"
+    job_role = posting.get("job_title") or "Software Engineer"
+    exp_level = posting.get("experience_level") or "Mid"
+    years_map = {"junior": 2, "entry": 1, "mid": 5, "senior": 8, "lead": 10}
+    years = years_map.get(str(exp_level).lower(), 5)
+
+    profile_prompt = (
+        "You are an expert tech career simulator. Your task is to generate a "
+        "detailed, realistic, and \"spiky\" profile for a fictional tech job "
+        "candidate based on a given role and experience level. The profile must be "
+        "returned as a single, well-formed JSON object.\n\n"
+        "**Instructions:**\n\n"
+        "1.  **Generate a Profile:** Create a candidate profile based on the following input variables:\n"
+        f"    * `job_role`: `{job_role}`\n"
+        f"    * `experience_level`: `{exp_level}`\n"
+        f"    * `years_of_experience`: `{years}`\n\n"
+        "2.  **Ensure \"Spiky\" Skills:** The `skill_matrix` is the most important part. "
+        "The proficiency scores MUST be intentionally uneven to reflect a real person's skillset.\n"
+        "    * The candidate must have 2-3 clear \"spikes\" (skills with proficiency 9-10).\n"
+        "    * The candidate must have at least one significant \"valley\" (a relevant skill with proficiency 1-3).\n"
+        "    * Other skills should be distributed realistically across the \"Familiar\" and \"Proficient\" ranges.\n"
+        "    * Use the following proficiency scale:\n"
+        "        * 1-2: Beginner\n"
+        "        * 3-5: Familiar\n"
+        "        * 6-8: Proficient\n"
+        "        * 9-10: Expert\n\n"
+        "3.  **Link Snippets to Spikes:** The `project_snippets` must be directly linked to the candidate's highest-rated skills (their \"spikes\"). Each snippet should provide a narrative \"proof\" of their expertise in that area. The stories should be concise and written in the first person.\n\n"
+        "4.  **JSON Output Only:** The final output MUST be a single, raw JSON object. Do not include any introductory text, explanations, markdown formatting like ```json, or anything else outside of the JSON structure.\n\n"
+        "**JSON Schema:**\n\n"
+        "{"
+        "  \"core_identity\": {\n"
+        "    \"name\": \"string (Generate a realistic name)\",\n"
+        "    \"applying_for\": \"string (Use the provided job_role)\",\n"
+        "    \"experience_level\": \"string (Use the provided experience_level)\",\n"
+        "    \"years_of_experience\": \"integer (Use the provided years_of_experience)\"\n"
+        "  },\n"
+        "  \"skill_matrix\": [\n"
+        "    {\n"
+        "      \"skill\": \"string\",\n"
+        "      \"category\": \"string (e.g., 'Languages', 'Frameworks', 'Databases', 'Tools/Infra', 'Concepts')\",\n"
+        "      \"proficiency\": \"integer (1-10)\"\n"
+        "    }\n"
+        "  ],\n"
+        "  \"project_snippets\": [\n"
+        "    {\n"
+        "      \"linked_skill\": \"string (The 'spike' skill this story relates to)\",\n"
+        "      \"story\": \"string (A first-person project story using the STAR method implicitly)\"\n"
+        "    }\n"
+        "  ],\n"
+        "  \"personality\": {\n"
+        "    \"confidence\": \"string (e.g., 'High', 'Medium', 'Low')\",\n"
+        "    \"verbosity\": \"string (e.g., 'Concise', 'Balanced', 'Verbose')\",\n"
+        "    \"quirk\": \"string (A unique, subtle interview behavior)\"\n"
+        "  }\n"
+        "}"
     )
 
-    data = await gateway.execute_task(
+    profile_data = await gateway.execute_task(
+        task_name="fake_candidate_profile",
+        system_prompt=profile_prompt,
+    )
+
+    profile_json = ""
+    if isinstance(profile_data, dict):
+        try:
+            profile_json = json.dumps(profile_data)
+        except Exception:
+            profile_json = json.dumps({})
+    else:
+        profile_json = str(profile_data)
+
+    resume_prompt = (
+        "Using the following candidate profile and job description, craft a concise "
+        "resume paragraph summarizing the candidate's relevant experience. Respond "
+        "ONLY with a JSON object containing a 'resume' field.\n\n"
+        f"Candidate Profile:\n{profile_json}\n\n"
+        f"Job Description:\n{posting['description']}"
+    )
+
+    resume_data = await gateway.execute_task(
         task_name="fake_candidate_resume",
-        system_prompt=system_prompt,
+        system_prompt=resume_prompt,
     )
 
-    resume_text = data.get("resume") or data.get("text") or ""
+    resume_text = ""
+    if isinstance(resume_data, dict):
+        resume_text = resume_data.get("resume") or resume_data.get("text") or ""
+    else:
+        resume_text = str(resume_data)
+
     candidate_id = str(uuid.uuid4())
+    samples.upsert_candidate(candidate_id, job_id, profile_json, resume_text)
+    # Maintain legacy resume table for compatibility
     samples.upsert_candidate_resume(candidate_id, resume_text, job_id)
-    return {"candidate_id": candidate_id, "resume": resume_text}
+    return {"candidate_id": candidate_id, "profile": json.loads(profile_json or "{}"), "resume": resume_text}
 
 
 async def generate_auto_answer_for_session(
@@ -53,6 +125,9 @@ async def generate_auto_answer_for_session(
     *,
     job_description: Optional[str] = None,
     candidate_resume: Optional[str] = None,
+    candidate_profile: Optional[str] = None,
+    candidate_id: Optional[str] = None,
+    job_id: Optional[int] = None,
 ) -> Dict[str, str]:
     """Generate a candidate-style answer to the latest question in a session.
 
@@ -68,6 +143,12 @@ async def generate_auto_answer_for_session(
         Full job description text (optional; falls back to blueprint evidence).
     candidate_resume: Optional[str]
         Full resume text (optional; falls back to blueprint evidence).
+    candidate_profile: Optional[str]
+        Full candidate profile JSON (optional).
+    candidate_id: Optional[str]
+        Candidate identifier to link with session for analytics.
+    job_id: Optional[int]
+        Job posting identifier to link with session for analytics.
     """
     # Clamp the levels to [0, 1]
     try:
@@ -146,6 +227,8 @@ async def generate_auto_answer_for_session(
     parts.append(f"Latest Question:\n{last_q}")
     if rez_text:
         parts.append(f"Candidate Resume (context):\n{rez_text}")
+    if candidate_profile:
+        parts.append(f"Candidate Profile (context):\n{candidate_profile}")
     if jd_text:
         parts.append(f"Job Description / Responsibilities (context):\n{jd_text}")
     if history_text:
@@ -173,5 +256,11 @@ async def generate_auto_answer_for_session(
             answer = str(data).strip()
         except Exception:
             answer = ""
+
+    if candidate_id and job_id:
+        try:
+            samples.link_candidate_session(candidate_id, int(job_id), session_id)
+        except Exception:
+            pass
 
     return {"answer_text": answer or ""}

--- a/services/sample_data_service/sample_data_repo.py
+++ b/services/sample_data_service/sample_data_repo.py
@@ -52,6 +52,29 @@ def init_db() -> None:
             )
             """
         )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS candidates (
+                candidate_id TEXT PRIMARY KEY,
+                job_id INTEGER NOT NULL,
+                profile TEXT NOT NULL,
+                resume TEXT NOT NULL,
+                FOREIGN KEY(job_id) REFERENCES job_postings(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS candidate_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                candidate_id TEXT NOT NULL,
+                job_id INTEGER NOT NULL,
+                session_id TEXT NOT NULL,
+                FOREIGN KEY(candidate_id) REFERENCES candidates(candidate_id),
+                FOREIGN KEY(job_id) REFERENCES job_postings(id)
+            )
+            """
+        )
         conn.commit()
 
 
@@ -150,3 +173,44 @@ def get_candidate_resume(candidate_id: str) -> Optional[Dict[str, Any]]:
             "resume": row["resume"],
             "job_id": row["job_id"],
         }
+
+
+def upsert_candidate(candidate_id: str, job_id: int, profile: str, resume: str) -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO candidates(candidate_id, job_id, profile, resume)
+            VALUES(?,?,?,?)
+            """,
+            (candidate_id, job_id, profile, resume),
+        )
+        conn.commit()
+
+
+def get_candidate(candidate_id: str) -> Optional[Dict[str, Any]]:
+    with get_connection() as conn:
+        cur = conn.execute(
+            "SELECT candidate_id, job_id, profile, resume FROM candidates WHERE candidate_id = ?",
+            (candidate_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        return {
+            "candidate_id": row["candidate_id"],
+            "job_id": row["job_id"],
+            "profile": row["profile"],
+            "resume": row["resume"],
+        }
+
+
+def link_candidate_session(candidate_id: str, job_id: int, session_id: str) -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO candidate_sessions(candidate_id, job_id, session_id)
+            VALUES(?,?,?)
+            """,
+            (candidate_id, job_id, session_id),
+        )
+        conn.commit()

--- a/test_frontend/chat.js
+++ b/test_frontend/chat.js
@@ -28,7 +28,10 @@ function initChat() {
     const ORCH_BASE = sessionStorage.getItem('AI_SERVICE_URL') || 'http://localhost:8003';
     const context = {
         job_description: sessionStorage.getItem('job_description') || '',
-        candidate_resume: sessionStorage.getItem('candidate_resume') || ''
+        candidate_resume: sessionStorage.getItem('candidate_resume') || '',
+        candidate_profile: sessionStorage.getItem('candidate_profile') || '',
+        candidate_id: sessionStorage.getItem('candidate_id') || '',
+        job_id: sessionStorage.getItem('job_id') || ''
     };
 
     const history = [];
@@ -289,7 +292,10 @@ function initChat() {
                 correctness_level: isNaN(corr) ? 0.8 : corr,
                 confidence_level: isNaN(conf) ? 0.7 : conf,
                 job_description: context.job_description || '',
-                candidate_resume: context.candidate_resume || ''
+                candidate_resume: context.candidate_resume || '',
+                candidate_profile: context.candidate_profile || '',
+                candidate_id: context.candidate_id || '',
+                job_id: context.job_id || ''
             };
             addLog('Auto-generating candidate answer...');
             const resp = await fetch(`${ORCH_BASE}/api/v1/sessions/${sessionId}/auto-answer`, {

--- a/test_frontend/index.html
+++ b/test_frontend/index.html
@@ -98,10 +98,12 @@
                 parts.push(`Required Qualifications:\n${bullets}`);
             }
             jobDescEl.value = parts.join('\n\n');
+            sessionStorage.setItem('job_id', id);
             if (testingMode) {
                 const gen = await fetch(`${AI_SERVICE_URL}/app-test/generate-candidate/${id}`, { method: 'POST' });
                 const cand = await gen.json();
                 if (cand.candidate_id) sessionStorage.setItem('candidate_id', cand.candidate_id);
+                if (cand.profile) sessionStorage.setItem('candidate_profile', JSON.stringify(cand.profile));
                 resumeEl.value = cand.resume || '';
             }
             updateStartButtonState();
@@ -163,6 +165,10 @@
         sessionStorage.setItem('candidate_resume', resume);
         const cid = sessionStorage.getItem('candidate_id') || '';
         sessionStorage.setItem('candidate_id', cid);
+        const cprof = sessionStorage.getItem('candidate_profile') || '';
+        sessionStorage.setItem('candidate_profile', cprof);
+        const jobId = sessionStorage.getItem('job_id') || '';
+        sessionStorage.setItem('job_id', jobId);
         sessionStorage.setItem('time_limit', timeLimit);
         sessionStorage.setItem('word_limit', wordLimit);
         window.location.href = 'chat.html';


### PR DESCRIPTION
## Summary
- store candidate profile and resume in new SQLite tables
- generate structured candidate profiles and resumes for jobs
- include candidate profile and identifiers when auto-answering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be14d0c9bc83289e2a08ce0d41b382