### PR TITLE
Expand warm-up flow with structured steps

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -20,12 +20,6 @@ from .programs.stage0_analysis import (
     Stage0AnalysisProgram,
     JDResumeAnalysisInput,
 )
-from .programs.stage1_warmup import (
-    WarmupOverviewProgram,
-    WarmupOverviewInput,
-    WarmupConstraintProgram,
-    WarmupConstraintInput,
-)
 from .programs.stage2_evidence import (
     EvidenceProgram,
     EvidenceInput,
@@ -201,8 +195,6 @@ _interviewer = LLMInterviewer()
 _monitor = LLMMonitor()
 _scoring = ScoringEngine()
 _stage0 = Stage0AnalysisProgram()
-_warmup_overview = WarmupOverviewProgram()
-_warmup_constraint = WarmupConstraintProgram()
 _evidence = EvidenceProgram()
 _theory_question = TheoryQuestionProgram()
 _theory_eval = TheoryEvalProgram()
@@ -239,40 +231,160 @@ async def analyze_jd_resume(
     return packet
 
 
-async def warmup_overview(
+async def warmup_select_project(
     packet: ContextPacket, answer: Optional[str] = None
-) -> Optional[str]:
-    """Stage-1: Ask for a project overview and record goal and constraints."""
-
-    if answer is None:
-        prompt = (
-            "Give me a 60–90 sec overview of a project most relevant to "
-            f"{packet.primary_overlap_focus}: goal, your role, key constraints."
-        )
-        _decrement_time(packet, 1)
-        return prompt
-
-    out = await _warmup_overview(WarmupOverviewInput(answer=answer))
-    packet.project_context.goal = out.goal
-    packet.project_context.constraints = out.constraints
-    return None
-
-
-async def warmup_constraint(
-    packet: ContextPacket, answer: Optional[str] = None
-) -> Optional[str]:
-    """Stage-1: Ask about hardest constraint and capture scale/latency info."""
+) -> Optional[dict]:
+    """Warm-up step: have the candidate pick a project."""
 
     if answer is None:
         question = (
-            "What was the hardest constraint (scale, latency/SLA, reliability, cost) "
-            "and how did it shape your design?"
+            "Name the project most relevant to "
+            f"{packet.primary_overlap_focus}. Reply with the project name only."
         )
         _decrement_time(packet, 1)
-        return question
+        return {"question_text": question, "question_type": "warmup_project"}
 
-    out = await _warmup_constraint(WarmupConstraintInput(answer=answer))
-    packet.project_context.scale_latency_slo = out.scale_latency_slo
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt='Extract the project name. Respond with JSON {"project_name": string}.',
+        user_prompt=answer,
+    )
+    packet.selected_project = data.get("project_name")
+    return None
+
+
+async def warmup_role_context(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: capture role and team size."""
+
+    if answer is None:
+        question = (
+            f"In one sentence, what was your role and team size on {packet.selected_project}? "
+            "Be concise."
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": question, "question_type": "warmup_role"}
+
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt=(
+            'Extract role and team_size. Respond with JSON {"role": string, "team_size": string}.'
+        ),
+        user_prompt=answer,
+    )
+    packet.project_context.role = data.get("role")
+    packet.project_context.team_size = data.get("team_size")
+    return None
+
+
+async def warmup_architecture(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: high-level architecture and technologies."""
+
+    if answer is None:
+        question = (
+            "Briefly describe the high-level architecture and key technologies. "
+            "Answer in one sentence."
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": question, "question_type": "warmup_architecture"}
+
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt=(
+            'Extract architecture and key_technologies (list). Respond with JSON {"architecture": string, "key_technologies": [string]}.'
+        ),
+        user_prompt=answer,
+    )
+    packet.project_context.architecture = data.get("architecture")
+    packet.project_context.key_technologies = data.get("key_technologies", [])
+    return None
+
+
+async def warmup_constraints(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: capture key constraints."""
+
+    if answer is None:
+        question = (
+            "List the main technical constraints you faced (e.g., scale, latency). "
+            "Keep it short."
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": question, "question_type": "warmup_constraints"}
+
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt='Extract constraints as a list. Respond with JSON {"constraints": [string]}.',
+        user_prompt=answer,
+    )
+    packet.project_context.constraints = data.get("constraints", [])
+    return None
+
+
+async def warmup_challenge(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: hardest challenge faced."""
+
+    if answer is None:
+        question = (
+            "What was the toughest technical challenge and how did you address it? One sentence."
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": question, "question_type": "warmup_challenge"}
+
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt='Extract the challenge. Respond with JSON {"challenge": string}.',
+        user_prompt=answer,
+    )
+    packet.project_context.challenge = data.get("challenge")
+    return None
+
+
+async def warmup_outcome(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: outcomes or metrics achieved."""
+
+    if answer is None:
+        question = (
+            "What measurable outcome or metric did the project achieve? One sentence."
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": question, "question_type": "warmup_outcome"}
+
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt='Extract the outcome or metrics. Respond with JSON {"outcome": string}.',
+        user_prompt=answer,
+    )
+    packet.project_context.outcome = data.get("outcome")
+    return None
+
+
+async def warmup_reflection(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: reflection or lessons learned."""
+
+    if answer is None:
+        question = (
+            "Looking back, what would you improve or do differently? One sentence."
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": question, "question_type": "warmup_reflection"}
+
+    data = await gateway.execute_task(
+        task_name="stage_1_parse",
+        system_prompt='Extract reflection. Respond with JSON {"reflection": string}.',
+        user_prompt=answer,
+    )
+    packet.project_context.reflection = data.get("reflection")
     return None
 
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -3,8 +3,13 @@
 from typing import Any, Optional
 
 from .llm_api import (
-    warmup_overview,
-    warmup_constraint,
+    warmup_select_project,
+    warmup_role_context,
+    warmup_architecture,
+    warmup_constraints,
+    warmup_challenge,
+    warmup_outcome,
+    warmup_reflection,
     evidence_skill_question,
     theory_check_question,
     wrap_up,
@@ -16,20 +21,24 @@ class Orchestrator:
 
     async def decide_next_action(
         self, state: Any, answer: Optional[str] = None
-    ) -> Optional[str]:
+    ) -> Optional[dict]:
         packet = state.packet
         phase = state.current_phase
 
         if phase == "warm_up":
-            if state.warmup_step == 0:
-                q = await warmup_overview(packet, answer)
-                if q is None:
-                    state.warmup_step = 1
-                    return await self.decide_next_action(state, None)
-                return q
-            q = await warmup_constraint(packet, answer)
+            step = state.current_warmup_step
+            func_map = {
+                "select_project": warmup_select_project,
+                "role_context": warmup_role_context,
+                "architecture": warmup_architecture,
+                "constraints": warmup_constraints,
+                "challenge": warmup_challenge,
+                "outcome": warmup_outcome,
+                "reflection": warmup_reflection,
+            }
+            q = await func_map[step](packet, answer)
             if q is None:
-                state.advance_phase()
+                state.advance_warmup_step()
                 return await self.decide_next_action(state, None)
             return q
 
@@ -38,23 +47,24 @@ class Orchestrator:
             if q is None:
                 state.advance_phase()
                 return await self.decide_next_action(state, None)
-            return q
+            return {"question_text": q, "question_type": "evidence_skill"}
 
         if phase == "theory":
             q = await theory_check_question(packet, answer)
             if q is None:
                 state.advance_phase()
                 return await self.decide_next_action(state, None)
-            return q
+            return {"question_text": q, "question_type": "theory_check"}
 
         if phase == "wrap_up":
             q = await wrap_up(packet, answer)
             if q is None:
                 state.advance_phase()
-            return q
+                return None
+            return {"question_text": q, "question_type": "wrap_up"}
 
         return None
 
-    async def loop(self, state: Any, answer: Optional[str] = None) -> Optional[str]:
-        """Return the next question string or None if the interview has ended."""
+    async def loop(self, state: Any, answer: Optional[str] = None) -> Optional[dict]:
+        """Return the next question payload or None if the interview has ended."""
         return await self.decide_next_action(state, answer)

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -76,6 +76,13 @@ class ProjectContext(BaseModel):
     goal: Optional[str] = None
     constraints: List[str] = Field(default_factory=list)
     scale_latency_slo: Optional[str] = None
+    role: Optional[str] = None
+    team_size: Optional[str] = None
+    architecture: Optional[str] = None
+    key_technologies: List[str] = Field(default_factory=list)
+    challenge: Optional[str] = None
+    outcome: Optional[str] = None
+    reflection: Optional[str] = None
 
 
 class VerificationResult(BaseModel):

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -9,12 +9,21 @@ class InterviewState:
     """Tracks the shared context packet and phase progression."""
 
     phases: List[str] = ["warm_up", "evidence", "theory", "wrap_up"]
+    warmup_steps: List[str] = [
+        "select_project",
+        "role_context",
+        "architecture",
+        "constraints",
+        "challenge",
+        "outcome",
+        "reflection",
+    ]
 
     def __init__(self, packet: ContextPacket) -> None:
         self.packet = packet
         self.phase_index = 0
-        # Stage-1 warm-up consists of two questions; track progress
-        self.warmup_step = 0
+        # Stage-1 warm-up progresses through enumerated steps
+        self.warmup_index = 0
 
     @property
     def current_phase(self) -> str:
@@ -24,6 +33,17 @@ class InterviewState:
         """Move to the next interview phase if available."""
         if self.phase_index < len(self.phases) - 1:
             self.phase_index += 1
+
+    @property
+    def current_warmup_step(self) -> str:
+        return self.warmup_steps[self.warmup_index]
+
+    def advance_warmup_step(self) -> None:
+        if self.warmup_index < len(self.warmup_steps) - 1:
+            self.warmup_index += 1
+        else:
+            # No more warm-up steps; advance to next phase
+            self.advance_phase()
 
     def decrement_time(self, minutes: int) -> None:
         """Convenience helper to reduce remaining interview time."""

--- a/services/session_service/service.py
+++ b/services/session_service/service.py
@@ -23,6 +23,8 @@ class ConnectionManager:
         self.orchestrator = Orchestrator()
         # Track session IDs per connection for DB persistence
         self.session_ids: Dict[WebSocket, str] = {}
+        # Track last question type for logging answers
+        self.question_types: Dict[WebSocket, str] = {}
 
     async def connect(self, websocket: WebSocket, session_id: str) -> None:
         await websocket.accept()
@@ -32,6 +34,7 @@ class ConnectionManager:
         self.states.pop(websocket, None)
         self.history.pop(websocket, None)
         self.session_ids.pop(websocket, None)
+        self.question_types.pop(websocket, None)
 
     async def handle_message(self, websocket: WebSocket, data: dict) -> None:
         event = data.get("event")
@@ -101,9 +104,12 @@ class ConnectionManager:
                 pass
 
             prev_stage = state.current_phase
-            question = await self.orchestrator.loop(state)
-            if question:
+            q_payload = await self.orchestrator.loop(state)
+            if q_payload:
+                question = q_payload["question_text"]
+                qtype = q_payload.get("question_type")
                 self.history[websocket].append({"role": "interviewer", "message": question})
+                self.question_types[websocket] = qtype or ""
                 # If stage advanced during orchestration, inform client
                 try:
                     if state.current_phase != prev_stage:
@@ -115,10 +121,15 @@ class ConnectionManager:
                     await websocket.send_json({"event": "context_packet", "payload": state.packet.model_dump()})
                 except Exception:
                     pass
-                # Persist interviewer question so auto-answer can find it
+                # Persist interviewer question with metadata
                 try:
                     if session_id:
-                        log_turn(session_id, "interviewer", question)
+                        log_turn(
+                            session_id,
+                            "interviewer",
+                            question,
+                            {"stage": state.current_phase, "question_type": qtype},
+                        )
                 except Exception:
                     pass
                 await websocket.send_json(
@@ -127,6 +138,7 @@ class ConnectionManager:
                         "payload": {
                             "question_text": question,
                             "stage": state.current_phase,
+                            "question_type": qtype,
                         },
                     }
                 )
@@ -139,17 +151,23 @@ class ConnectionManager:
             payload = data.get("payload", {})
             # Support both payload shapes
             answer = payload.get("answer") or payload.get("answer_text") or ""
-            # Persist candidate answer
+            # Persist candidate answer with metadata
             try:
                 session_id = self.session_ids.get(websocket)
+                qtype = self.question_types.get(websocket)
                 if session_id and answer:
-                    log_turn(session_id, "candidate", answer)
+                    log_turn(
+                        session_id,
+                        "candidate",
+                        answer,
+                        {"stage": state.current_phase, "question_type": qtype},
+                    )
             except Exception:
                 pass
             self.history.setdefault(websocket, []).append({"role": "candidate", "message": answer})
             prev_stage = state.current_phase
-            question = await self.orchestrator.loop(state, answer)
-            if question is None:
+            q_payload = await self.orchestrator.loop(state, answer)
+            if q_payload is None:
                 # If we just transitioned into wrap_up and ended, emit stage_changed once
                 try:
                     if prev_stage != "wrap_up":
@@ -165,7 +183,10 @@ class ConnectionManager:
                 await websocket.close()
                 self.disconnect(websocket)
                 return
+            question = q_payload["question_text"]
+            qtype = q_payload.get("question_type")
             self.history[websocket].append({"role": "interviewer", "message": question})
+            self.question_types[websocket] = qtype or ""
             # If stage advanced during orchestration, inform client
             try:
                 if state.current_phase != prev_stage:
@@ -181,7 +202,12 @@ class ConnectionManager:
             try:
                 session_id = self.session_ids.get(websocket)
                 if session_id and question:
-                    log_turn(session_id, "interviewer", question)
+                    log_turn(
+                        session_id,
+                        "interviewer",
+                        question,
+                        {"stage": state.current_phase, "question_type": qtype},
+                    )
             except Exception:
                 pass
             await websocket.send_json(
@@ -190,6 +216,7 @@ class ConnectionManager:
                     "payload": {
                         "question_text": question,
                         "stage": state.current_phase,
+                        "question_type": qtype,
                     },
                 }
             )

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -13,29 +13,43 @@ from session_service.interview_state import InterviewState
 @pytest.mark.asyncio
 async def test_stage_flow(monkeypatch):
     async def fake_execute(task_name, system_prompt, user_prompt=None):
-        mapping = {
-            "stage_0_analysis": {
+        if task_name == "stage_0_analysis":
+            return {
                 "role_from_jd": "backend",
                 "jd_core_skills": ["python"],
                 "resume_claims": ["python"],
                 "overlap_skills": ["python"],
                 "primary_overlap_focus": "python",
-            },
-            "stage_1_parse": {
-                "goal": "demo",
-                "constraints": ["latency"],
-                "scale_latency_slo": "100rps",
-            },
-            "stage_2_parse": {
+            }
+        if task_name == "stage_1_parse":
+            if "project name" in system_prompt:
+                return {"project_name": "demo"}
+            if "team_size" in system_prompt:
+                return {"role": "lead", "team_size": "5"}
+            if "architecture" in system_prompt:
+                return {"architecture": "svc", "key_technologies": ["python"]}
+            if "constraints" in system_prompt and "list" in system_prompt:
+                return {"constraints": ["latency"]}
+            if "challenge" in system_prompt:
+                return {"challenge": "scaling"}
+            if "outcome" in system_prompt or "metrics" in system_prompt:
+                return {"outcome": "100rps"}
+            if "reflection" in system_prompt:
+                return {"reflection": "tests"}
+            return {"goal": "demo"}
+        if task_name == "stage_2_parse":
+            return {
                 "skill_hooks": ["python"],
                 "confidence_ratings": {"python": 5},
                 "notes": ["api work"],
-            },
-            "stage_3_question": {"question_text": "What is Python?"},
-            "stage_3_eval": {"result": "pass", "rationale": "ok"},
-            "stage_4_summary": {"strengths": ["reasoning"], "risks": [], "follow_ups": []},
-        }
-        return mapping[task_name]
+            }
+        if task_name == "stage_3_question":
+            return {"question_text": "What is Python?"}
+        if task_name == "stage_3_eval":
+            return {"result": "pass", "rationale": "ok"}
+        if task_name == "stage_4_summary":
+            return {"strengths": ["reasoning"], "risks": [], "follow_ups": []}
+        return {}
 
     monkeypatch.setattr(ai.gateway, "execute_task", fake_execute)
 
@@ -44,21 +58,36 @@ async def test_stage_flow(monkeypatch):
     orch = Orchestrator()
 
     q1 = await orch.loop(state)
-    assert "overview" in q1.lower()
+    assert q1["question_type"] == "warmup_project"
 
-    q2 = await orch.loop(state, "Built service")
-    assert "hardest constraint" in q2.lower()
+    q2 = await orch.loop(state, "demo project")
+    assert q2["question_type"] == "warmup_role"
 
-    q3 = await orch.loop(state, "Latency shaped design")
-    assert "components you directly built" in q3.lower()
+    q3 = await orch.loop(state, "Lead of team 5")
+    assert q3["question_type"] == "warmup_architecture"
 
-    q4 = await orch.loop(state, "API using python confidence 5")
-    assert q4 == "What is Python?"
+    q4 = await orch.loop(state, "svc using python")
+    assert q4["question_type"] == "warmup_constraints"
 
-    q5 = await orch.loop(state, "A language")
-    assert q5 == "Any questions about the role, roadmap, or stack?"
+    q5 = await orch.loop(state, "latency under 100ms")
+    assert q5["question_type"] == "warmup_challenge"
 
-    q6 = await orch.loop(state, "No questions")
-    assert q6 is None
+    q6 = await orch.loop(state, "scaling issues")
+    assert q6["question_type"] == "warmup_outcome"
+
+    q7 = await orch.loop(state, "100rps")
+    assert q7["question_type"] == "warmup_reflection"
+
+    q8 = await orch.loop(state, "better tests")
+    assert q8["question_type"] == "evidence_skill"
+
+    q9 = await orch.loop(state, "component details confidence 5")
+    assert q9["question_type"] == "theory_check"
+
+    q10 = await orch.loop(state, "A language")
+    assert q10["question_type"] == "wrap_up"
+
+    q11 = await orch.loop(state, "No questions")
+    assert q11 is None
     assert state.packet.time_remaining_min == 0
 


### PR DESCRIPTION
## Summary
- Replace warm-up counter with explicit step tracking
- Add LLM helpers for project selection, role context, architecture, constraints, challenge, outcome, and reflection
- Log question type and stage for interviewer and candidate turns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c33aadd4a0832896f23091d2e940fc