### PR TITLE
Expand project context and warm-up parsing

### DIFF
--- a/services/orchestrator_service/flow.py
+++ b/services/orchestrator_service/flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from langgraph.graph import StateGraph, START, END
 
-from .schemas import ContextPacket, ProjectContext, VerificationResult
+from .schemas import ContextPacket, VerificationResult
 from .programs.stage0_analysis import Stage0AnalysisProgram, JDResumeAnalysisInput
 from .programs.stage1_warmup import (
     WarmupOverviewProgram,
@@ -37,11 +37,10 @@ async def stage1_warmup_node(state: InterviewState) -> dict:
     """Parse warm-up responses into project context."""
     overview = await WarmupOverviewProgram()(WarmupOverviewInput(answer=state.selected_project or ""))
     constraint = await WarmupConstraintProgram()(WarmupConstraintInput(answer=state.project_context.scale_latency_slo or ""))
-    ctx = ProjectContext(
-        goal=overview.goal,
-        constraints=overview.constraints,
-        scale_latency_slo=constraint.scale_latency_slo,
-    )
+    ctx = state.project_context.model_copy()
+    ctx.goal = overview.goal
+    ctx.constraints = overview.constraints
+    ctx.scale_latency_slo = constraint.scale_latency_slo
     return {"project_context": ctx.model_dump()}
 
 

--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -20,6 +20,20 @@ from .programs.stage0_analysis import (
     Stage0AnalysisProgram,
     JDResumeAnalysisInput,
 )
+from .programs.stage1_warmup import (
+    WarmupRoleProgram,
+    WarmupRoleInput,
+    WarmupArchitectureProgram,
+    WarmupArchitectureInput,
+    WarmupConstraintsProgram,
+    WarmupConstraintsInput,
+    WarmupChallengeProgram,
+    WarmupChallengeInput,
+    WarmupOutcomeProgram,
+    WarmupOutcomeInput,
+    WarmupReflectionProgram,
+    WarmupReflectionInput,
+)
 from .programs.stage2_evidence import (
     EvidenceProgram,
     EvidenceInput,
@@ -268,15 +282,9 @@ async def warmup_role_context(
         _decrement_time(packet, 1)
         return {"question_text": question, "question_type": "warmup_role"}
 
-    data = await gateway.execute_task(
-        task_name="stage_1_parse",
-        system_prompt=(
-            'Extract role and team_size. Respond with JSON {"role": string, "team_size": string}.'
-        ),
-        user_prompt=answer,
-    )
-    packet.project_context.role = data.get("role")
-    packet.project_context.team_size = data.get("team_size")
+    data = await WarmupRoleProgram()(WarmupRoleInput(answer=answer))
+    packet.project_context.role = data.role
+    packet.project_context.team_size = data.team_size
     return None
 
 
@@ -293,15 +301,9 @@ async def warmup_architecture(
         _decrement_time(packet, 1)
         return {"question_text": question, "question_type": "warmup_architecture"}
 
-    data = await gateway.execute_task(
-        task_name="stage_1_parse",
-        system_prompt=(
-            'Extract architecture and key_technologies (list). Respond with JSON {"architecture": string, "key_technologies": [string]}.'
-        ),
-        user_prompt=answer,
-    )
-    packet.project_context.architecture = data.get("architecture")
-    packet.project_context.key_technologies = data.get("key_technologies", [])
+    data = await WarmupArchitectureProgram()(WarmupArchitectureInput(answer=answer))
+    packet.project_context.architecture = data.architecture
+    packet.project_context.key_technologies = data.key_technologies
     return None
 
 
@@ -318,12 +320,8 @@ async def warmup_constraints(
         _decrement_time(packet, 1)
         return {"question_text": question, "question_type": "warmup_constraints"}
 
-    data = await gateway.execute_task(
-        task_name="stage_1_parse",
-        system_prompt='Extract constraints as a list. Respond with JSON {"constraints": [string]}.',
-        user_prompt=answer,
-    )
-    packet.project_context.constraints = data.get("constraints", [])
+    data = await WarmupConstraintsProgram()(WarmupConstraintsInput(answer=answer))
+    packet.project_context.constraints = data.constraints
     return None
 
 
@@ -339,12 +337,8 @@ async def warmup_challenge(
         _decrement_time(packet, 1)
         return {"question_text": question, "question_type": "warmup_challenge"}
 
-    data = await gateway.execute_task(
-        task_name="stage_1_parse",
-        system_prompt='Extract the challenge. Respond with JSON {"challenge": string}.',
-        user_prompt=answer,
-    )
-    packet.project_context.challenge = data.get("challenge")
+    data = await WarmupChallengeProgram()(WarmupChallengeInput(answer=answer))
+    packet.project_context.hardest_challenge = data.hardest_challenge
     return None
 
 
@@ -360,12 +354,8 @@ async def warmup_outcome(
         _decrement_time(packet, 1)
         return {"question_text": question, "question_type": "warmup_outcome"}
 
-    data = await gateway.execute_task(
-        task_name="stage_1_parse",
-        system_prompt='Extract the outcome or metrics. Respond with JSON {"outcome": string}.',
-        user_prompt=answer,
-    )
-    packet.project_context.outcome = data.get("outcome")
+    data = await WarmupOutcomeProgram()(WarmupOutcomeInput(answer=answer))
+    packet.project_context.outcomes = data.outcomes
     return None
 
 
@@ -381,12 +371,8 @@ async def warmup_reflection(
         _decrement_time(packet, 1)
         return {"question_text": question, "question_type": "warmup_reflection"}
 
-    data = await gateway.execute_task(
-        task_name="stage_1_parse",
-        system_prompt='Extract reflection. Respond with JSON {"reflection": string}.',
-        user_prompt=answer,
-    )
-    packet.project_context.reflection = data.get("reflection")
+    data = await WarmupReflectionProgram()(WarmupReflectionInput(answer=answer))
+    packet.project_context.lessons = data.lessons
     return None
 
 

--- a/services/orchestrator_service/programs/stage1_warmup.py
+++ b/services/orchestrator_service/programs/stage1_warmup.py
@@ -39,20 +39,49 @@ class WarmupOverviewProgram(dspy.Module):
         return WarmupOverviewOutput.model_validate(data)
 
 
+class WarmupConstraintsInput(BaseModel):
+    """User answer listing key constraints."""
+
+    answer: str
+
+
+class WarmupConstraintsOutput(BaseModel):
+    """Extracted constraint details."""
+
+    constraints: List[str] = Field(default_factory=list)
+
+
+class WarmupConstraintsProgram(dspy.Module):
+    """Parse constraint list from an answer."""
+
+    system_prompt: str = (
+        "Extract the list of constraints from the answer. "
+        'Respond with JSON {"constraints": [string]}.'
+    )
+
+    async def __call__(self, inp: WarmupConstraintsInput) -> WarmupConstraintsOutput:
+        data = await gateway.execute_task(
+            task_name="stage_1_parse",
+            system_prompt=self.system_prompt,
+            user_prompt=inp.answer,
+        )
+        return WarmupConstraintsOutput.model_validate(data)
+
+
 class WarmupConstraintInput(BaseModel):
-    """User answer explaining hardest constraint."""
+    """User answer explaining scale or latency details."""
 
     answer: str
 
 
 class WarmupConstraintOutput(BaseModel):
-    """Extracted scale/latency/SLO details."""
+    """Extracted scale/latency/SLO information."""
 
     scale_latency_slo: Optional[str] = None
 
 
 class WarmupConstraintProgram(dspy.Module):
-    """Parse constraint details from an answer."""
+    """Parse scale or latency constraints from an answer."""
 
     system_prompt: str = (
         "Extract any scale, latency, or SLO details from the answer. "
@@ -66,3 +95,145 @@ class WarmupConstraintProgram(dspy.Module):
             user_prompt=inp.answer,
         )
         return WarmupConstraintOutput.model_validate(data)
+
+
+class WarmupRoleInput(BaseModel):
+    """User answer describing role and team size."""
+
+    answer: str
+
+
+class WarmupRoleOutput(BaseModel):
+    """Extracted role and team size."""
+
+    role: Optional[str] = None
+    team_size: Optional[str] = None
+
+
+class WarmupRoleProgram(dspy.Module):
+    """Parse role context details."""
+
+    system_prompt: str = (
+        'Extract role and team_size. Respond with JSON {"role": string, "team_size": string}.'
+    )
+
+    async def __call__(self, inp: WarmupRoleInput) -> WarmupRoleOutput:
+        data = await gateway.execute_task(
+            task_name="stage_1_parse",
+            system_prompt=self.system_prompt,
+            user_prompt=inp.answer,
+        )
+        return WarmupRoleOutput.model_validate(data)
+
+
+class WarmupArchitectureInput(BaseModel):
+    """User answer describing architecture and technologies."""
+
+    answer: str
+
+
+class WarmupArchitectureOutput(BaseModel):
+    """Extracted architecture details."""
+
+    architecture: Optional[str] = None
+    key_technologies: List[str] = Field(default_factory=list)
+
+
+class WarmupArchitectureProgram(dspy.Module):
+    """Parse architecture information."""
+
+    system_prompt: str = (
+        'Extract architecture and key_technologies (list). Respond with JSON {"architecture": string, "key_technologies": [string]}.'
+    )
+
+    async def __call__(self, inp: WarmupArchitectureInput) -> WarmupArchitectureOutput:
+        data = await gateway.execute_task(
+            task_name="stage_1_parse",
+            system_prompt=self.system_prompt,
+            user_prompt=inp.answer,
+        )
+        return WarmupArchitectureOutput.model_validate(data)
+
+
+class WarmupChallengeInput(BaseModel):
+    """User answer describing the hardest challenge."""
+
+    answer: str
+
+
+class WarmupChallengeOutput(BaseModel):
+    """Extracted hardest challenge."""
+
+    hardest_challenge: Optional[str] = None
+
+
+class WarmupChallengeProgram(dspy.Module):
+    """Parse hardest challenge from answer."""
+
+    system_prompt: str = (
+        'Extract the hardest challenge. Respond with JSON {"hardest_challenge": string}.'
+    )
+
+    async def __call__(self, inp: WarmupChallengeInput) -> WarmupChallengeOutput:
+        data = await gateway.execute_task(
+            task_name="stage_1_parse",
+            system_prompt=self.system_prompt,
+            user_prompt=inp.answer,
+        )
+        return WarmupChallengeOutput.model_validate(data)
+
+
+class WarmupOutcomeInput(BaseModel):
+    """User answer describing project outcomes."""
+
+    answer: str
+
+
+class WarmupOutcomeOutput(BaseModel):
+    """Extracted project outcomes."""
+
+    outcomes: Optional[str] = None
+
+
+class WarmupOutcomeProgram(dspy.Module):
+    """Parse project outcomes."""
+
+    system_prompt: str = (
+        'Extract the project outcomes or metrics. Respond with JSON {"outcomes": string}.'
+    )
+
+    async def __call__(self, inp: WarmupOutcomeInput) -> WarmupOutcomeOutput:
+        data = await gateway.execute_task(
+            task_name="stage_1_parse",
+            system_prompt=self.system_prompt,
+            user_prompt=inp.answer,
+        )
+        return WarmupOutcomeOutput.model_validate(data)
+
+
+class WarmupReflectionInput(BaseModel):
+    """User answer describing lessons learned."""
+
+    answer: str
+
+
+class WarmupReflectionOutput(BaseModel):
+    """Extracted lessons learned."""
+
+    lessons: Optional[str] = None
+
+
+class WarmupReflectionProgram(dspy.Module):
+    """Parse lessons learned from answer."""
+
+    system_prompt: str = (
+        'Extract the lessons. Respond with JSON {"lessons": string}.'
+    )
+
+    async def __call__(self, inp: WarmupReflectionInput) -> WarmupReflectionOutput:
+        data = await gateway.execute_task(
+            task_name="stage_1_parse",
+            system_prompt=self.system_prompt,
+            user_prompt=inp.answer,
+        )
+        return WarmupReflectionOutput.model_validate(data)

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -80,9 +80,9 @@ class ProjectContext(BaseModel):
     team_size: Optional[str] = None
     architecture: Optional[str] = None
     key_technologies: List[str] = Field(default_factory=list)
-    challenge: Optional[str] = None
-    outcome: Optional[str] = None
-    reflection: Optional[str] = None
+    hardest_challenge: Optional[str] = None
+    outcomes: Optional[str] = None
+    lessons: Optional[str] = None
 
 
 class VerificationResult(BaseModel):

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -7,6 +7,8 @@ import pytest
 
 from orchestrator_service import llm_api as ai
 from orchestrator_service.schemas import ContextPacket, ProjectContext
+from orchestrator_service.orchestrator import Orchestrator
+from session_service.interview_state import InterviewState
 
 
 @pytest.mark.asyncio
@@ -29,12 +31,12 @@ async def test_run_interview_end_to_end(monkeypatch):
                 return {"architecture": "svc", "key_technologies": ["python"]}
             if "constraints" in system_prompt and "list" in system_prompt:
                 return {"constraints": ["latency"]}
-            if "challenge" in system_prompt:
-                return {"challenge": "scaling"}
-            if "outcome" in system_prompt or "metrics" in system_prompt:
-                return {"outcome": "100rps"}
-            if "reflection" in system_prompt:
-                return {"reflection": "tests"}
+            if "hardest_challenge" in system_prompt or "challenge" in system_prompt:
+                return {"hardest_challenge": "scaling"}
+            if "outcomes" in system_prompt or "metrics" in system_prompt:
+                return {"outcomes": "100rps"}
+            if "lessons" in system_prompt or "reflection" in system_prompt:
+                return {"lessons": "tests"}
             return {"goal": "demo"}
         if task_name == "stage_2_parse":
             return {
@@ -42,6 +44,8 @@ async def test_run_interview_end_to_end(monkeypatch):
                 "confidence_ratings": {"python": 5},
                 "notes": ["api work"],
             }
+        if task_name == "question_generation":
+            return {"question_text": "components?"}
         if task_name == "stage_3_question":
             return {"question_text": "What is Python?"}
         if task_name == "stage_3_eval":


### PR DESCRIPTION
## Summary
- Extend `ProjectContext` with role, team size, architecture, hardest challenge, outcomes, and lessons fields
- Add Stage-1 warm-up parsers for role, architecture, constraints, challenge, outcomes, and lessons; update warm-up helper functions
- Adjust flow to parse warm-up data into `ProjectContext` and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c341135ec8832884d2aa879c5be725