### PR TITLE
Enhance skill tagging in interview analysis

### DIFF
--- a/services/common/skill_inventory.py
+++ b/services/common/skill_inventory.py
@@ -1,0 +1,1 @@
+SKILL_INVENTORY = {"backend": ["scaling", "caching"], "frontend": ["state management"]}

--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -12,6 +12,7 @@ from .schemas import (
     VerificationResult,
 )
 from gateway_service import gateway
+from common.skill_inventory import SKILL_INVENTORY
 from interviewer_service.personas import PERSONA_PROMPTS
 from interviewer_service import LLMInterviewer
 from monitor_service import LLMMonitor
@@ -233,6 +234,23 @@ async def analyze_jd_resume(
         JDResumeAnalysisInput(jd_text=jd_text, resume_text=resume_text)
     )
 
+    canonical_tags = SKILL_INVENTORY.get(out.role_from_jd or "", [])
+    data = await gateway.execute_task(
+        task_name="skill_tag_refinement",
+        system_prompt=(
+            "Expand the provided canonical skill tags with additional related tags found in the job description and resume. "
+            "Respond with JSON {\"tags\": [string]}"
+        ),
+        user_prompt=(
+            f"Role: {out.role_from_jd}\n"
+            f"Canonical tags: {canonical_tags}\n"
+            f"Job description: {jd_text}\n"
+            f"Resume: {resume_text}"
+        ),
+    )
+    expanded_tags = data.get("tags", [])
+    merged_tags = list(dict.fromkeys(list(canonical_tags) + list(expanded_tags)))
+
     packet = ContextPacket(
         jd_text=jd_text,
         resume_text=resume_text,
@@ -242,6 +260,7 @@ async def analyze_jd_resume(
         resume_claims=out.resume_claims,
         overlap_skills=out.overlap_skills,
         primary_overlap_focus=out.primary_overlap_focus,
+        role_skill_tags=merged_tags,
     )
     packet.time_remaining_min = packet.duration_min
     return packet
@@ -382,6 +401,8 @@ async def evidence_skill_question(
     """Stage-2: Gather concrete responsibilities and skill hooks."""
 
     skills = packet.overlap_skills or packet.jd_core_skills
+    if packet.role_skill_tags:
+        skills = list(dict.fromkeys(list(packet.role_skill_tags) + list(skills)))
 
     if answer is None:
         skill_list = ", ".join(skills)

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -111,3 +111,4 @@ class ContextPacket(BaseModel):
     confidence_ratings: Dict[str, int] = Field(default_factory=dict)
     verifications: List[VerificationResult] = Field(default_factory=list)
     notes: List[str] = Field(default_factory=list)
+    role_skill_tags: List[str] = Field(default_factory=list)

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -22,6 +22,8 @@ async def test_run_interview_end_to_end(monkeypatch):
                 "overlap_skills": ["python"],
                 "primary_overlap_focus": "python",
             }
+        if task_name == "skill_tag_refinement":
+            return {"tags": []}
         if task_name == "stage_1_parse":
             if "project name" in system_prompt:
                 return {"project_name": "demo"}

--- a/services/tests/test_session_state.py
+++ b/services/tests/test_session_state.py
@@ -13,20 +13,24 @@ from session_service.interview_state import InterviewState
 @pytest.mark.asyncio
 async def test_context_packet_creation(monkeypatch):
     async def fake_execute(task_name, system_prompt, user_prompt=None):
-        assert task_name == "stage_0_analysis"
-        return {
-            "role_from_jd": "backend",
-            "jd_core_skills": ["python"],
-            "resume_claims": ["python"],
-            "overlap_skills": ["python"],
-            "primary_overlap_focus": "python",
-        }
+        if task_name == "stage_0_analysis":
+            return {
+                "role_from_jd": "backend",
+                "jd_core_skills": ["python"],
+                "resume_claims": ["python"],
+                "overlap_skills": ["python"],
+                "primary_overlap_focus": "python",
+            }
+        if task_name == "skill_tag_refinement":
+            return {"tags": ["python"]}
+        raise AssertionError(f"Unexpected task {task_name}")
 
     monkeypatch.setattr(ai.gateway, "execute_task", fake_execute)
 
     packet = await ai.analyze_jd_resume("JD", "Resume")
     assert isinstance(packet, ContextPacket)
     assert packet.role_from_jd == "backend"
+    assert packet.role_skill_tags == ["scaling", "caching", "python"]
     assert packet.time_remaining_min == packet.duration_min
 
 


### PR DESCRIPTION
## Summary
- Add shared skill inventory for canonical role tags
- Enrich ContextPacket with role_skill_tags and refine via gateway
- Merge role skill tags into Stage 2 evidence question

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c34bccbd1c83288f428310d7b96d89