### PR TITLE
feat: add evidence and wrap-up step orchestration

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -395,10 +395,31 @@ async def warmup_reflection(
     return None
 
 
-async def evidence_skill_question(
+async def evidence_components(
     packet: ContextPacket, answer: Optional[str] = None
-) -> Optional[str]:
-    """Stage-2: Gather concrete responsibilities and skill hooks."""
+) -> Optional[dict]:
+    """Stage-2 step: ask about project components owned."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate to briefly list 2–3 major components they built or owned on the selected project, "
+            "including each component's purpose and main interfaces. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 2)
+        return {"question_text": data["question_text"], "question_type": "evidence_components"}
+
+    packet.notes.append(f"Components: {answer}")
+    return None
+
+
+async def evidence_skill_task(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-2 step: gather skill confidence from a task description."""
 
     skills = packet.overlap_skills or packet.jd_core_skills
     if packet.role_skill_tags:
@@ -407,16 +428,15 @@ async def evidence_skill_question(
     if answer is None:
         skill_list = ", ".join(skills)
         system_prompt = (
-            "You are an AI technical interviewer. Generate a question asking the candidate to name 2–3 components they directly built or owned, "
-            "including each component's purpose, main interfaces, and their exact contribution. Also ask them to describe one task completed and rate their confidence 1–5 for each of the following skills: "
+            "You are an AI technical interviewer. Ask the candidate to describe one concrete task they completed and to rate their confidence (1-5) for each of these skills: "
             f"{skill_list}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
             task_name="question_generation",
             system_prompt=system_prompt,
         )
-        _decrement_time(packet, 4)
-        return data["question_text"]
+        _decrement_time(packet, 2)
+        return {"question_text": data["question_text"], "question_type": "evidence_skill_task"}
 
     out = await _evidence(EvidenceInput(answer=answer))
     packet.skill_hooks = out.skill_hooks
@@ -455,8 +475,10 @@ async def theory_check_question(
     return None
 
 
-async def wrap_up(packet: ContextPacket, answer: Optional[str] = None) -> Optional[str]:
-    """Stage-4: Conclude the interview and capture a summary."""
+async def wrapup_closure(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-4 step: invite final questions and capture summary."""
 
     if answer is None:
         notes = "; ".join(packet.notes)
@@ -469,7 +491,7 @@ async def wrap_up(packet: ContextPacket, answer: Optional[str] = None) -> Option
             system_prompt=system_prompt,
         )
         _decrement_time(packet, 1)
-        return data["question_text"]
+        return {"question_text": data["question_text"], "question_type": "wrapup_closure"}
 
     out = await _wrap_up(
         WrapUpInput(notes=packet.notes, verifications=packet.verifications)

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -10,9 +10,10 @@ from .llm_api import (
     warmup_challenge,
     warmup_outcome,
     warmup_reflection,
-    evidence_skill_question,
+    evidence_components,
+    evidence_skill_task,
     theory_check_question,
-    wrap_up,
+    wrapup_closure,
 )
 
 
@@ -43,11 +44,16 @@ class Orchestrator:
             return q
 
         if phase == "evidence":
-            q = await evidence_skill_question(packet, answer)
+            step = state.current_evidence_step
+            func_map = {
+                "components": evidence_components,
+                "skill_task": evidence_skill_task,
+            }
+            q = await func_map[step](packet, answer)
             if q is None:
-                state.advance_phase()
+                state.advance_evidence_step()
                 return await self.decide_next_action(state, None)
-            return {"question_text": q, "question_type": "evidence_skill"}
+            return q
 
         if phase == "theory":
             q = await theory_check_question(packet, answer)
@@ -57,11 +63,15 @@ class Orchestrator:
             return {"question_text": q, "question_type": "theory_check"}
 
         if phase == "wrap_up":
-            q = await wrap_up(packet, answer)
-            if q is None:
-                state.advance_phase()
+            if state.wrapup_index >= len(state.wrapup_steps):
                 return None
-            return {"question_text": q, "question_type": "wrap_up"}
+            step = state.current_wrapup_step
+            func_map = {"closure": wrapup_closure}
+            q = await func_map[step](packet, answer)
+            if q is None:
+                state.advance_wrapup_step()
+                return await self.decide_next_action(state, None)
+            return q
 
         return None
 

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -18,12 +18,21 @@ class InterviewState:
         "outcome",
         "reflection",
     ]
+    evidence_steps: List[str] = [
+        "components",
+        "skill_task",
+    ]
+    wrapup_steps: List[str] = [
+        "closure",
+    ]
 
     def __init__(self, packet: ContextPacket) -> None:
         self.packet = packet
         self.phase_index = 0
-        # Stage-1 warm-up progresses through enumerated steps
+        # Stage-based step indexes
         self.warmup_index = 0
+        self.evidence_index = 0
+        self.wrapup_index = 0
 
     @property
     def current_phase(self) -> str:
@@ -43,6 +52,28 @@ class InterviewState:
             self.warmup_index += 1
         else:
             # No more warm-up steps; advance to next phase
+            self.advance_phase()
+
+    @property
+    def current_evidence_step(self) -> str:
+        return self.evidence_steps[self.evidence_index]
+
+    def advance_evidence_step(self) -> None:
+        if self.evidence_index < len(self.evidence_steps) - 1:
+            self.evidence_index += 1
+        else:
+            self.evidence_index += 1
+            self.advance_phase()
+
+    @property
+    def current_wrapup_step(self) -> str:
+        return self.wrapup_steps[self.wrapup_index]
+
+    def advance_wrapup_step(self) -> None:
+        if self.wrapup_index < len(self.wrapup_steps) - 1:
+            self.wrapup_index += 1
+        else:
+            self.wrapup_index += 1
             self.advance_phase()
 
     def decrement_time(self, minutes: int) -> None:

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -84,15 +84,18 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q7["question_type"] == "warmup_reflection"
 
     q8 = await orch.loop(state, "better tests")
-    assert q8["question_type"] == "evidence_skill"
+    assert q8["question_type"] == "evidence_components"
 
-    q9 = await orch.loop(state, "component details confidence 5")
-    assert q9["question_type"] == "theory_check"
+    q9 = await orch.loop(state, "component details")
+    assert q9["question_type"] == "evidence_skill_task"
 
-    q10 = await orch.loop(state, "A language")
-    assert q10["question_type"] == "wrap_up"
+    q10 = await orch.loop(state, "task details confidence 5")
+    assert q10["question_type"] == "theory_check"
 
-    q11 = await orch.loop(state, "No questions")
-    assert q11 is None
+    q11 = await orch.loop(state, "A language")
+    assert q11["question_type"] == "wrapup_closure"
+
+    q12 = await orch.loop(state, "No questions")
+    assert q12 is None
     assert state.packet.time_remaining_min == 0
 


### PR DESCRIPTION
## Summary
- add evidence and wrap-up step lists to session state
- introduce evidence_components, evidence_skill_task, and wrapup_closure helpers for question generation
- iterate through evidence and wrap-up steps in orchestrator and update end-to-end test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c34ed203708328a8c9e9021950e7a2