### PR TITLE
Log interview Q&A pairs to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,4 +211,5 @@ uv.lock
 extern/voices/*
 research/*
 
+services/session_service/question_logs.db
 services/sample_data_service/data/samples.db

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -14,6 +14,7 @@ from .llm_api import (
     theory_check_question,
     wrap_up,
 )
+from session_service.question_log_db import log_question_response
 
 
 class Orchestrator:
@@ -26,6 +27,15 @@ class Orchestrator:
         phase = state.current_phase
 
         if phase == "warm_up":
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage=phase,
+                    question_type=getattr(state, "last_question_type", ""),
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
             step = state.current_warmup_step
             func_map = {
                 "select_project": warmup_select_project,
@@ -40,27 +50,62 @@ class Orchestrator:
             if q is None:
                 state.advance_warmup_step()
                 return await self.decide_next_action(state, None)
+            state.last_question_text = q.get("question_text")
+            state.last_question_type = q.get("question_type")
             return q
 
         if phase == "evidence":
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage=phase,
+                    question_type=getattr(state, "last_question_type", ""),
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
             q = await evidence_skill_question(packet, answer)
             if q is None:
                 state.advance_phase()
                 return await self.decide_next_action(state, None)
+            state.last_question_text = q
+            state.last_question_type = "evidence_skill"
             return {"question_text": q, "question_type": "evidence_skill"}
 
         if phase == "theory":
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage=phase,
+                    question_type=getattr(state, "last_question_type", ""),
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
             q = await theory_check_question(packet, answer)
             if q is None:
                 state.advance_phase()
                 return await self.decide_next_action(state, None)
+            state.last_question_text = q
+            state.last_question_type = "theory_check"
             return {"question_text": q, "question_type": "theory_check"}
 
         if phase == "wrap_up":
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage=phase,
+                    question_type=getattr(state, "last_question_type", ""),
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
             q = await wrap_up(packet, answer)
             if q is None:
                 state.advance_phase()
                 return None
+            state.last_question_text = q
+            state.last_question_type = "wrap_up"
             return {"question_text": q, "question_type": "wrap_up"}
 
         return None

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -1,6 +1,6 @@
 """State management for stage-based interview sessions."""
 
-from typing import List
+from typing import List, Optional
 
 from orchestrator_service.schemas import ContextPacket
 
@@ -19,11 +19,22 @@ class InterviewState:
         "reflection",
     ]
 
-    def __init__(self, packet: ContextPacket) -> None:
+    def __init__(
+        self,
+        packet: ContextPacket,
+        session_id: Optional[str] = None,
+        candidate_id: Optional[str] = None,
+    ) -> None:
         self.packet = packet
         self.phase_index = 0
         # Stage-1 warm-up progresses through enumerated steps
         self.warmup_index = 0
+        # Metadata for logging
+        self.session_id = session_id
+        self.candidate_id = candidate_id
+        # Track the last question asked to pair with the next answer
+        self.last_question_text: Optional[str] = None
+        self.last_question_type: Optional[str] = None
 
     @property
     def current_phase(self) -> str:

--- a/services/session_service/question_log_db.py
+++ b/services/session_service/question_log_db.py
@@ -1,0 +1,60 @@
+import sqlite3
+from datetime import datetime, UTC
+from pathlib import Path
+from typing import Optional
+
+DB_PATH = Path(__file__).resolve().with_name("question_logs.db")
+
+
+def init_db(db_path: Path = DB_PATH) -> None:
+    """Initialize the SQLite database for question/answer logs."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS question_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            candidate_id TEXT,
+            stage TEXT,
+            question_type TEXT,
+            question_text TEXT,
+            answer_text TEXT,
+            timestamp TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def log_question_response(
+    stage: str,
+    question_type: str,
+    question_text: str,
+    answer_text: str,
+    session_id: Optional[str] = None,
+    candidate_id: Optional[str] = None,
+    db_path: Path = DB_PATH,
+) -> None:
+    """Persist a single question/answer pair to the log database."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO question_logs (session_id, candidate_id, stage, question_type, question_text, answer_text, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            session_id,
+            candidate_id,
+            stage,
+            question_type,
+            question_text,
+            answer_text,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+# Ensure the database exists on import
+init_db()

--- a/services/session_service/service.py
+++ b/services/session_service/service.py
@@ -61,12 +61,17 @@ class ConnectionManager:
                 payload.get("candidate_resume", ""),
                 duration_min=(time_limit if isinstance(time_limit, int) and time_limit > 0 else 18),
             )
-            state = InterviewState(packet)
+            session_id = self.session_ids.get(websocket)
+            candidate_id = payload.get("candidate_id")
+            state = InterviewState(
+                packet,
+                session_id=session_id,
+                candidate_id=candidate_id,
+            )
             self.states[websocket] = state
             self.history[websocket] = []
 
             # Persist a session row so REST APIs can find it
-            session_id = self.session_ids.get(websocket)
             try:
                 create_session(
                     session_id=session_id or "",


### PR DESCRIPTION
## Summary
- Add question log database to record each question/answer with metadata
- Track session, candidate, and last question in state for logging
- Log each turn from orchestrator to persistent question log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c350c88d948328966267d3ef20fd2e