### PR TITLE
Expand evidence interview steps

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -35,10 +35,6 @@ from .programs.stage1_warmup import (
     WarmupReflectionProgram,
     WarmupReflectionInput,
 )
-from .programs.stage2_evidence import (
-    EvidenceProgram,
-    EvidenceInput,
-)
 from .programs.stage3_theory import (
     TheoryQuestionProgram,
     TheoryQuestionInput,
@@ -211,7 +207,6 @@ _interviewer = LLMInterviewer()
 _monitor = LLMMonitor()
 _scoring = ScoringEngine()
 _stage0 = Stage0AnalysisProgram()
-_evidence = EvidenceProgram()
 _theory_question = TheoryQuestionProgram()
 _theory_eval = TheoryEvalProgram()
 _wrap_up = WrapUpProgram()
@@ -447,32 +442,107 @@ async def evidence_components(
     return None
 
 
-async def evidence_skill_task(
+async def evidence_choice_space(
     packet: ContextPacket, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Stage-2 step: gather skill confidence from a task description."""
-
-    skills = packet.overlap_skills or packet.jd_core_skills
-    if packet.role_skill_tags:
-        skills = list(dict.fromkeys(list(packet.role_skill_tags) + list(skills)))
+    """Stage-2 step: ask about considered options or approaches."""
 
     if answer is None:
-        skill_list = ", ".join(skills)
         system_prompt = (
-            "You are an AI technical interviewer. Ask the candidate to describe one concrete task they completed and to rate their confidence (1-5) for each of these skills: "
-            f"{skill_list}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+            "You are an AI technical interviewer. Ask the candidate what options or approaches they considered for the chosen project. "
+            "The question must be brief and request a concise response. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
             task_name="question_generation",
             system_prompt=system_prompt,
         )
-        _decrement_time(packet, 2)
-        return {"question_text": data["question_text"], "question_type": "evidence_skill_task"}
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_choice_space"}
 
-    out = await _evidence(EvidenceInput(answer=answer))
-    packet.skill_hooks = out.skill_hooks
-    packet.confidence_ratings.update(out.confidence_ratings)
-    packet.notes.extend(out.notes)
+    data = await gateway.execute_task(
+        task_name="stage_2_parse",
+        system_prompt='Extract the options or approaches mentioned as short notes. Respond with JSON {"notes": [string]}.' ,
+        user_prompt=answer,
+    )
+    packet.notes.extend([f"Choice space: {n}" for n in data.get("notes", [])])
+    return None
+
+
+async def evidence_decision_rationale(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-2 step: probe why a specific option was chosen."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate to briefly explain why they chose a particular option from the ones considered. "
+            "Keep the question concise and expect a short answer. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_decision_rationale"}
+
+    data = await gateway.execute_task(
+        task_name="stage_2_parse",
+        system_prompt='Summarize the candidate\'s rationale in under 10 words. Respond with JSON {"notes": [string]}.' ,
+        user_prompt=answer,
+    )
+    packet.notes.extend([f"Rationale: {n}" for n in data.get("notes", [])])
+    return None
+
+
+async def evidence_outcome_validation(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-2 step: request evidence that the choice worked."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate for brief evidence that their chosen option succeeded. "
+            "The question must be concise. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_outcome_validation"}
+
+    data = await gateway.execute_task(
+        task_name="stage_2_parse",
+        system_prompt='List the pieces of evidence that the choice worked. Respond with JSON {"notes": [string]}.' ,
+        user_prompt=answer,
+    )
+    packet.notes.extend([f"Outcome: {n}" for n in data.get("notes", [])])
+    return None
+
+
+async def evidence_tradeoff_reflection(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-2 step: explore trade-offs or alternative paths."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate to reflect on trade-offs or alternative paths they considered and why those were not chosen. "
+            "Keep it brief and expect a concise answer. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_tradeoff_reflection"}
+
+    data = await gateway.execute_task(
+        task_name="stage_2_parse",
+        system_prompt='Summarize the trade-offs or alternatives mentioned. Respond with JSON {"notes": [string]}.' ,
+        user_prompt=answer,
+    )
+    packet.notes.extend([f"Trade-offs: {n}" for n in data.get("notes", [])])
     return None
 
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -11,7 +11,10 @@ from .llm_api import (
     warmup_outcome,
     warmup_reflection,
     evidence_components,
-    evidence_skill_task,
+    evidence_choice_space,
+    evidence_decision_rationale,
+    evidence_outcome_validation,
+    evidence_tradeoff_reflection,
     theory_check_question,
     wrapup_closure,
 )
@@ -69,7 +72,10 @@ class Orchestrator:
             step = state.current_evidence_step
             func_map = {
                 "components": evidence_components,
-                "skill_task": evidence_skill_task,
+                "choice_space": evidence_choice_space,
+                "decision_rationale": evidence_decision_rationale,
+                "outcome_validation": evidence_outcome_validation,
+                "tradeoff_reflection": evidence_tradeoff_reflection,
             }
             q = await func_map[step](packet, answer)
 

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -20,7 +20,10 @@ class InterviewState:
     ]
     evidence_steps: List[str] = [
         "components",
-        "skill_task",
+        "choice_space",
+        "decision_rationale",
+        "outcome_validation",
+        "tradeoff_reflection",
     ]
     wrapup_steps: List[str] = [
         "closure",

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -87,15 +87,24 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q8["question_type"] == "evidence_components"
 
     q9 = await orch.loop(state, "component details")
-    assert q9["question_type"] == "evidence_skill_task"
+    assert q9["question_type"] == "evidence_choice_space"
 
-    q10 = await orch.loop(state, "task details confidence 5")
-    assert q10["question_type"] == "theory_check"
+    q10 = await orch.loop(state, "considered options")
+    assert q10["question_type"] == "evidence_decision_rationale"
 
-    q11 = await orch.loop(state, "A language")
-    assert q11["question_type"] == "wrapup_closure"
+    q11 = await orch.loop(state, "selected because")
+    assert q11["question_type"] == "evidence_outcome_validation"
 
-    q12 = await orch.loop(state, "No questions")
-    assert q12 is None
+    q12 = await orch.loop(state, "it worked")
+    assert q12["question_type"] == "evidence_tradeoff_reflection"
+
+    q13 = await orch.loop(state, "tradeoffs considered")
+    assert q13["question_type"] == "theory_check"
+
+    q14 = await orch.loop(state, "A language")
+    assert q14["question_type"] == "wrapup_closure"
+
+    q15 = await orch.loop(state, "No questions")
+    assert q15 is None
     assert state.packet.time_remaining_min == 0
 


### PR DESCRIPTION
## Summary
- Replace old evidence step with sequential choice space, rationale, outcome, and trade-off prompts
- Capture each evidence response via AI gateway and store concise notes on the context packet
- Iterate through new evidence steps in orchestrator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36bd9e644832880de84bbc1a4a001