### PR TITLE
Log evidence question responses

### DIFF
--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -59,16 +59,6 @@ class Orchestrator:
             return q
 
         if phase == "evidence":
-
-            if answer is not None and getattr(state, "last_question_text", None):
-                log_question_response(
-                    stage=phase,
-                    question_type=getattr(state, "last_question_type", ""),
-                    question_text=getattr(state, "last_question_text", ""),
-                    answer_text=answer,
-                    session_id=getattr(state, "session_id", None),
-                    candidate_id=getattr(state, "candidate_id", None),
-                )
             step = state.current_evidence_step
             func_map = {
                 "components": evidence_components,
@@ -78,6 +68,16 @@ class Orchestrator:
                 "tradeoff_reflection": evidence_tradeoff_reflection,
             }
             q = await func_map[step](packet, answer)
+
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage="evidence",
+                    question_type=step,
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
 
             if q is None:
                 state.advance_evidence_step()

--- a/services/tests/test_question_log_db.py
+++ b/services/tests/test_question_log_db.py
@@ -1,0 +1,29 @@
+import sqlite3
+from session_service.question_log_db import init_db, log_question_response
+
+
+def test_log_question_response_captures_question_and_answer(tmp_path):
+    db_path = tmp_path / "question_logs.db"
+    init_db(db_path)
+    log_question_response(
+        stage="evidence",
+        question_type="choice_space",
+        question_text="What options did you consider?",
+        answer_text="Option A and B",
+        session_id="s1",
+        candidate_id="c1",
+        db_path=db_path,
+    )
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT stage, question_type, question_text, answer_text FROM question_logs"
+    )
+    row = cur.fetchone()
+    conn.close()
+    assert row == (
+        "evidence",
+        "choice_space",
+        "What options did you consider?",
+        "Option A and B",
+    )


### PR DESCRIPTION
## Summary
- log evidence-stage answers with step-specific question types
- add database test verifying question text and answer capture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3710257d4832881edc20bc3cb842e