### PR TITLE
refactor: remove confidence ratings

### DIFF
--- a/services/orchestrator_service/flow.py
+++ b/services/orchestrator_service/flow.py
@@ -50,7 +50,6 @@ async def stage2_evidence_node(state: InterviewState) -> dict:
     output = await EvidenceProgram()(EvidenceInput(answer=answer))
     return {
         "skill_hooks": output.skill_hooks,
-        "confidence_ratings": output.confidence_ratings,
         "notes": state.notes + output.notes,
     }
 
@@ -65,8 +64,7 @@ async def stage3_theory_node(state: InterviewState) -> dict:
         return {}
 
     skill = state.skill_hooks[idx]
-    confidence = state.confidence_ratings.get(skill, 3)
-    question = await TheoryQuestionProgram()(TheoryQuestionInput(skill=skill, confidence=confidence))
+    question = await TheoryQuestionProgram()(TheoryQuestionInput(skill=skill))
     eval_result = await TheoryEvalProgram()(TheoryEvalInput(answer=""))
     verification = VerificationResult(
         skill=skill, result=eval_result.result, rationale=eval_result.rationale

--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -576,9 +576,8 @@ async def theory_check_question(
     skill = skills[idx]
 
     if answer is None:
-        confidence = packet.confidence_ratings.get(skill, 3)
         q_out = await _theory_question(
-            TheoryQuestionInput(skill=skill, confidence=confidence)
+            TheoryQuestionInput(skill=skill)
         )
         _decrement_time(packet, 1)
         return q_out.question_text

--- a/services/orchestrator_service/programs/stage2_evidence.py
+++ b/services/orchestrator_service/programs/stage2_evidence.py
@@ -1,7 +1,7 @@
 """DSPy program for Stage-2 evidence parsing."""
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import List
 
 import dspy
 from pydantic import BaseModel, Field
@@ -10,16 +10,15 @@ from gateway_service import gateway
 
 
 class EvidenceInput(BaseModel):
-    """User answer describing responsibilities and skill confidence."""
+    """User answer describing responsibilities and skills."""
 
     answer: str
 
 
 class EvidenceOutput(BaseModel):
-    """Parsed skill hooks, confidence ratings, and notes."""
+    """Parsed skill hooks and notes."""
 
     skill_hooks: List[str] = Field(default_factory=list)
-    confidence_ratings: Dict[str, int] = Field(default_factory=dict)
     notes: List[str] = Field(default_factory=list)
 
 
@@ -29,7 +28,6 @@ class EvidenceProgram(dspy.Module):
     system_prompt: str = (
         "From the answer, extract:"
         " skill_hooks (list of 3-5 concise items to verify later),"
-        " confidence_ratings (mapping skill->1-5),"
         " and notes (brief bullets)."
         " Respond with JSON containing these keys."
     )

--- a/services/orchestrator_service/programs/stage3_theory.py
+++ b/services/orchestrator_service/programs/stage3_theory.py
@@ -13,7 +13,6 @@ class TheoryQuestionInput(BaseModel):
     """Parameters for generating a theory check question."""
 
     skill: str
-    confidence: int
 
 
 class TheoryQuestionOutput(BaseModel):
@@ -26,15 +25,12 @@ class TheoryQuestionProgram(dspy.Module):
     """Generate a concept-first verification question."""
 
     system_prompt_template: str = (
-        "You are verifying understanding of '{skill}'. Candidate self-rated "
-        "confidence {confidence}/5. Ask one concise concept-first question. "
+        "You are verifying understanding of '{skill}'. Ask one concise concept-first question. "
         'Respond with JSON {{"question_text": string}}.'
     )
 
     async def __call__(self, inp: TheoryQuestionInput) -> TheoryQuestionOutput:
-        system_prompt = self.system_prompt_template.format(
-            skill=inp.skill, confidence=inp.confidence
-        )
+        system_prompt = self.system_prompt_template.format(skill=inp.skill)
         data = await gateway.execute_task(
             task_name="stage_3_question",
             system_prompt=system_prompt,

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -1,5 +1,5 @@
 """Pydantic models for the interview module."""
-from typing import Dict, List, Optional
+from typing import List, Optional
 from pydantic import BaseModel, Field
 
 
@@ -108,7 +108,6 @@ class ContextPacket(BaseModel):
     selected_project: Optional[str] = None
     project_context: ProjectContext = Field(default_factory=ProjectContext)
     skill_hooks: List[str] = Field(default_factory=list)
-    confidence_ratings: Dict[str, int] = Field(default_factory=dict)
     verifications: List[VerificationResult] = Field(default_factory=list)
     notes: List[str] = Field(default_factory=list)
     role_skill_tags: List[str] = Field(default_factory=list)

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -43,7 +43,6 @@ async def test_run_interview_end_to_end(monkeypatch):
         if task_name == "stage_2_parse":
             return {
                 "skill_hooks": ["python"],
-                "confidence_ratings": {"python": 5},
                 "notes": ["api work"],
             }
         if task_name == "question_generation":

--- a/services/tests/test_flow.py
+++ b/services/tests/test_flow.py
@@ -25,7 +25,6 @@ async def test_run_interview_flow(monkeypatch):
         if task_name == "stage_2_parse":
             return {
                 "skill_hooks": ["python", "db"],
-                "confidence_ratings": {"python": 5, "db": 4},
                 "notes": ["api work"],
             }
         if task_name == "stage_3_question":


### PR DESCRIPTION
## Summary
- drop `confidence_ratings` from interview context and evidence parsing
- simplify theory question prompts by removing confidence parameter
- update tests for confidence-free flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c372b3ff348328a60089819f83596e