### PR TITLE
Expand interview flow step handling and logging

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -564,44 +564,56 @@ async def evidence_tradeoff_reflection(
     return None
 
 
-async def theory_check_question(
-    packet: ContextPacket, answer: Optional[str] = None
-) -> Optional[str]:
-    """Stage-3: Verify fundamentals for each skill hook."""
-
-    skills = packet.skill_hooks or packet.jd_core_skills
-    idx = len(packet.verifications)
-    if idx >= len(skills):
-        return None
-    skill = skills[idx]
+async def theory_primary(
+    packet: ContextPacket, skill: str, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-3 step: ask a primary theory question for a skill."""
 
     if answer is None:
-        q_out = await _theory_question(
-            TheoryQuestionInput(skill=skill)
-        )
+        q_out = await _theory_question(TheoryQuestionInput(skill=skill))
         _decrement_time(packet, 1)
-        return q_out.question_text
+        return {"question_text": q_out.question_text, "question_type": "theory_primary"}
 
     e_out = await _theory_eval(TheoryEvalInput(answer=answer))
     packet.verifications.append(
-        VerificationResult(
-            skill=skill,
-            result=e_out.result,
-            rationale=e_out.rationale,
-        )
+        VerificationResult(skill=skill, result=e_out.result, rationale=e_out.rationale)
     )
     return None
 
 
-async def wrapup_closure(
+async def theory_follow_up(
+    packet: ContextPacket, skill: str, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-3 step: follow-up question on the same skill."""
+
+    if answer is None:
+        system_prompt = (
+            f"You are verifying understanding of '{skill}'. Ask one concise follow-up question. "
+            'Respond with JSON {"question_text": string}.'
+        )
+        data = await gateway.execute_task(
+            task_name="stage_3_question",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "theory_follow_up"}
+
+    e_out = await _theory_eval(TheoryEvalInput(answer=answer))
+    packet.verifications.append(
+        VerificationResult(skill=skill, result=e_out.result, rationale=e_out.rationale)
+    )
+    return None
+
+
+async def wrapup_candidate_questions(
     packet: ContextPacket, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Stage-4 step: invite final questions and capture summary."""
+    """Stage-4 step: invite candidate questions about the role or team."""
 
     if answer is None:
         notes = "; ".join(packet.notes)
         system_prompt = (
-            "You are an AI technical interviewer wrapping up the conversation. Based on these notes from the interview, generate a final personalized question inviting the candidate to ask about the role, roadmap, stack, or anything else. "
+            "You are an AI technical interviewer wrapping up the conversation. Based on these notes from the interview, ask the candidate in one short sentence if they have any questions about the role, team, or company. "
             f"Notes: {notes}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
@@ -609,11 +621,31 @@ async def wrapup_closure(
             system_prompt=system_prompt,
         )
         _decrement_time(packet, 1)
-        return {"question_text": data["question_text"], "question_type": "wrapup_closure"}
+        return {"question_text": data["question_text"], "question_type": "wrapup_candidate_questions"}
 
-    out = await _wrap_up(
-        WrapUpInput(notes=packet.notes, verifications=packet.verifications)
-    )
+    packet.notes.append(f"Candidate questions: {answer}")
+    return None
+
+
+async def wrapup_feedback(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-4 step: gather feedback and finalize summary."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer concluding the interview. Ask the candidate for brief feedback on this interview experience. "
+            "Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "wrapup_feedback"}
+
+    packet.notes.append(f"Candidate feedback: {answer}")
+    out = await _wrap_up(WrapUpInput(notes=packet.notes, verifications=packet.verifications))
     if out.strengths:
         packet.notes.append("Strengths: " + ", ".join(out.strengths))
     if out.risks:

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -15,8 +15,10 @@ from .llm_api import (
     evidence_decision_rationale,
     evidence_outcome_validation,
     evidence_tradeoff_reflection,
-    theory_check_question,
-    wrapup_closure,
+    theory_primary,
+    theory_follow_up,
+    wrapup_candidate_questions,
+    wrapup_feedback,
 )
 from session_service.question_log_db import log_question_response
 
@@ -97,28 +99,46 @@ class Orchestrator:
                     session_id=getattr(state, "session_id", None),
                     candidate_id=getattr(state, "candidate_id", None),
                 )
-            q = await theory_check_question(packet, answer)
-            if q is None:
+            skills = packet.skill_hooks or packet.jd_core_skills
+            if state.theory_skill_index >= len(skills):
                 state.advance_phase()
                 return await self.decide_next_action(state, None)
-            state.last_question_text = q
-            state.last_question_type = "theory_check"
-            return {"question_text": q, "question_type": "theory_check"}
+            step = state.current_theory_step
+            skill = skills[state.theory_skill_index]
+            func_map = {
+                "primary": theory_primary,
+                "follow_up": theory_follow_up,
+            }
+            q = await func_map[step](packet, skill, answer)
+            if q is None:
+                state.advance_theory_step()
+                return await self.decide_next_action(state, None)
+            state.last_question_text = q.get("question_text")
+            state.last_question_type = q.get("question_type")
+            return q
 
         if phase == "wrap_up":
+            if state.wrapup_index >= len(state.wrapup_steps):
+                state.advance_phase()
+                return None
+            step = state.current_wrapup_step
+            func_map = {
+                "candidate_questions": wrapup_candidate_questions,
+                "feedback": wrapup_feedback,
+            }
+            q = await func_map[step](packet, answer)
             if answer is not None and getattr(state, "last_question_text", None):
                 log_question_response(
                     stage=phase,
-                    question_type=getattr(state, "last_question_type", ""),
+                    question_type=step,
                     question_text=getattr(state, "last_question_text", ""),
                     answer_text=answer,
                     session_id=getattr(state, "session_id", None),
                     candidate_id=getattr(state, "candidate_id", None),
                 )
-            q = await wrapup_closure(packet, answer)
             if q is None:
-                state.advance_phase()
-                return None
+                state.advance_wrapup_step()
+                return await self.decide_next_action(state, None)
             state.last_question_text = q.get("question_text")
             state.last_question_type = q.get("question_type")
             return q

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -25,8 +25,13 @@ class InterviewState:
         "outcome_validation",
         "tradeoff_reflection",
     ]
+    theory_steps: List[str] = [
+        "primary",
+        "follow_up",
+    ]
     wrapup_steps: List[str] = [
-        "closure",
+        "candidate_questions",
+        "feedback",
     ]
 
     def __init__(
@@ -40,6 +45,8 @@ class InterviewState:
         # Stage-based step indexes
         self.warmup_index = 0
         self.evidence_index = 0
+        self.theory_index = 0
+        self.theory_skill_index = 0
         self.wrapup_index = 0
 
         # Metadata for logging
@@ -78,8 +85,21 @@ class InterviewState:
         if self.evidence_index < len(self.evidence_steps) - 1:
             self.evidence_index += 1
         else:
-            self.evidence_index += 1
             self.advance_phase()
+
+    @property
+    def current_theory_step(self) -> str:
+        return self.theory_steps[self.theory_index]
+
+    def advance_theory_step(self) -> None:
+        if self.theory_index < len(self.theory_steps) - 1:
+            self.theory_index += 1
+        else:
+            self.theory_index = 0
+            self.theory_skill_index += 1
+            skills = self.packet.skill_hooks or self.packet.jd_core_skills
+            if self.theory_skill_index >= len(skills):
+                self.advance_phase()
 
     @property
     def current_wrapup_step(self) -> str:

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -98,12 +98,18 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q12["question_type"] == "evidence_tradeoff_reflection"
 
     q13 = await orch.loop(state, "tradeoffs considered")
-    assert q13["question_type"] == "theory_check"
+    assert q13["question_type"] == "theory_primary"
 
     q14 = await orch.loop(state, "A language")
-    assert q14["question_type"] == "wrapup_closure"
+    assert q14["question_type"] == "theory_follow_up"
 
-    q15 = await orch.loop(state, "No questions")
-    assert q15 is None
+    q15 = await orch.loop(state, "deeper answer")
+    assert q15["question_type"] == "wrapup_candidate_questions"
+
+    q16 = await orch.loop(state, "No questions")
+    assert q16["question_type"] == "wrapup_feedback"
+
+    q17 = await orch.loop(state, "All good")
+    assert q17 is None
     assert state.packet.time_remaining_min == 0
 


### PR DESCRIPTION
## Summary
- Track theory and wrap-up stages with explicit step lists
- Add LLM helpers for theory primary/follow-up and wrap-up questions/feedback
- Iterate orchestration through new steps and log all Q&A pairs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c388da05988328bf7980ed9724b845