### PR TITLE
Add metrics and follow-up hooks to interview flow

### DIFF
--- a/services/orchestrator_service/flow.py
+++ b/services/orchestrator_service/flow.py
@@ -48,22 +48,27 @@ async def stage2_evidence_node(state: InterviewState) -> dict:
     """Extract evidence details from candidate answer."""
     answer = state.notes[-1] if state.notes else ""
     output = await EvidenceProgram()(EvidenceInput(answer=answer))
+    ctx = state.project_context.model_copy()
+    ctx.evaluation_metrics.update(output.evaluation_metrics)
     return {
         "skill_hooks": output.skill_hooks,
+        "followup_hooks": state.followup_hooks + output.followup_hooks,
         "notes": state.notes + output.notes,
+        "project_context": ctx.model_dump(),
     }
 
 
 async def stage3_theory_node(state: InterviewState) -> dict:
     """Run a theory check on each collected skill in sequence."""
-    if not state.skill_hooks:
+    skills = state.followup_hooks or state.skill_hooks
+    if not skills:
         return {}
 
     idx = len(state.verifications)
-    if idx >= len(state.skill_hooks):
+    if idx >= len(skills):
         return {}
 
-    skill = state.skill_hooks[idx]
+    skill = skills[idx]
     question = await TheoryQuestionProgram()(TheoryQuestionInput(skill=skill))
     eval_result = await TheoryEvalProgram()(TheoryEvalInput(answer=""))
     verification = VerificationResult(
@@ -96,7 +101,7 @@ def build_interview_graph() -> StateGraph:
     graph.add_edge("stage2_evidence", "stage3_theory")
 
     def _more_theory(state: InterviewState) -> str:
-        skills = state.skill_hooks or state.jd_core_skills
+        skills = state.followup_hooks or state.skill_hooks or state.jd_core_skills
         return "again" if len(state.verifications) < len(skills) else "done"
 
     graph.add_conditional_edges(

--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -225,11 +225,14 @@ def _skill_prompt_context(packet: ContextPacket) -> str:
 
     tags = ", ".join(packet.role_skill_tags[:5])
     hooks = ", ".join(packet.skill_hooks[:3])
+    followups = ", ".join(packet.followup_hooks[:3])
     parts = []
     if tags:
         parts.append(f"technologies like {tags}")
     if hooks:
         parts.append(f"constraints such as {hooks}")
+    if followups:
+        parts.append(f"topics such as {followups}")
     return (" involving " + " and ".join(parts)) if parts else ""
 
 
@@ -343,6 +346,8 @@ async def warmup_architecture(
     data = await WarmupArchitectureProgram()(WarmupArchitectureInput(answer=answer))
     packet.project_context.architecture = data.architecture
     packet.project_context.key_technologies = data.key_technologies
+    packet.project_context.followup_hooks = data.followup_hooks
+    packet.followup_hooks.extend(h for h in data.followup_hooks if h not in packet.followup_hooks)
     return None
 
 
@@ -409,6 +414,7 @@ async def warmup_outcome(
 
     data = await WarmupOutcomeProgram()(WarmupOutcomeInput(answer=answer))
     packet.project_context.outcomes = data.outcomes
+    packet.project_context.evaluation_metrics = data.evaluation_metrics
     return None
 
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -99,7 +99,7 @@ class Orchestrator:
                     session_id=getattr(state, "session_id", None),
                     candidate_id=getattr(state, "candidate_id", None),
                 )
-            skills = packet.skill_hooks or packet.jd_core_skills
+            skills = packet.followup_hooks or packet.skill_hooks or packet.jd_core_skills
             if state.theory_skill_index >= len(skills):
                 state.advance_phase()
                 return await self.decide_next_action(state, None)

--- a/services/orchestrator_service/programs/stage1_warmup.py
+++ b/services/orchestrator_service/programs/stage1_warmup.py
@@ -1,7 +1,7 @@
 """DSPy programs for Stage-1 warm-up parsing."""
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import dspy
 from pydantic import BaseModel, Field
@@ -137,13 +137,15 @@ class WarmupArchitectureOutput(BaseModel):
 
     architecture: Optional[str] = None
     key_technologies: List[str] = Field(default_factory=list)
+    followup_hooks: List[str] = Field(default_factory=list)
 
 
 class WarmupArchitectureProgram(dspy.Module):
     """Parse architecture information."""
 
     system_prompt: str = (
-        'Extract architecture and key_technologies (list). Respond with JSON {"architecture": string, "key_technologies": [string]}.'
+        'Extract architecture, key_technologies (list), and followup_hooks (list of technology keywords). '
+        'Respond with JSON {"architecture": string, "key_technologies": [string], "followup_hooks": [string]}.'
     )
 
     async def __call__(self, inp: WarmupArchitectureInput) -> WarmupArchitectureOutput:
@@ -193,13 +195,15 @@ class WarmupOutcomeOutput(BaseModel):
     """Extracted project outcomes."""
 
     outcomes: Optional[str] = None
+    evaluation_metrics: Dict[str, str] = Field(default_factory=dict)
 
 
 class WarmupOutcomeProgram(dspy.Module):
     """Parse project outcomes."""
 
     system_prompt: str = (
-        'Extract the project outcomes or metrics. Respond with JSON {"outcomes": string}.'
+        'Extract the project outcomes or metrics and any evaluation_metrics as key-value pairs. '
+        'Respond with JSON {"outcomes": string, "evaluation_metrics": {string: string}}.'
     )
 
     async def __call__(self, inp: WarmupOutcomeInput) -> WarmupOutcomeOutput:

--- a/services/orchestrator_service/programs/stage2_evidence.py
+++ b/services/orchestrator_service/programs/stage2_evidence.py
@@ -1,12 +1,11 @@
 """DSPy program for Stage-2 evidence parsing."""
 from __future__ import annotations
 
-from typing import List
-
 import dspy
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from gateway_service import gateway
+from ..schemas import EvidenceOutput
 
 
 class EvidenceInput(BaseModel):
@@ -15,19 +14,14 @@ class EvidenceInput(BaseModel):
     answer: str
 
 
-class EvidenceOutput(BaseModel):
-    """Parsed skill hooks and notes."""
-
-    skill_hooks: List[str] = Field(default_factory=list)
-    notes: List[str] = Field(default_factory=list)
-
-
 class EvidenceProgram(dspy.Module):
     """Parse Stage-2 evidence answers into structured data."""
 
     system_prompt: str = (
         "From the answer, extract:"
         " skill_hooks (list of 3-5 concise items to verify later),"
+        " evaluation_metrics (object of metric name to value),"
+        " followup_hooks (list of technology keywords),"
         " and notes (brief bullets)."
         " Respond with JSON containing these keys."
     )

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -1,5 +1,5 @@
 """Pydantic models for the interview module."""
-from typing import List, Optional
+from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
@@ -80,6 +80,8 @@ class ProjectContext(BaseModel):
     team_size: Optional[str] = None
     architecture: Optional[str] = None
     key_technologies: List[str] = Field(default_factory=list)
+    evaluation_metrics: Dict[str, str] = Field(default_factory=dict)
+    followup_hooks: List[str] = Field(default_factory=list)
     hardest_challenge: Optional[str] = None
     outcomes: Optional[str] = None
     lessons: Optional[str] = None
@@ -91,6 +93,15 @@ class VerificationResult(BaseModel):
     skill: str
     result: str
     rationale: Optional[str] = None
+
+
+class EvidenceOutput(BaseModel):
+    """Parsed skill hooks, metrics, follow-up hooks, and notes."""
+
+    skill_hooks: List[str] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)
+    evaluation_metrics: Dict[str, str] = Field(default_factory=dict)
+    followup_hooks: List[str] = Field(default_factory=list)
 
 
 class ContextPacket(BaseModel):
@@ -108,6 +119,7 @@ class ContextPacket(BaseModel):
     selected_project: Optional[str] = None
     project_context: ProjectContext = Field(default_factory=ProjectContext)
     skill_hooks: List[str] = Field(default_factory=list)
+    followup_hooks: List[str] = Field(default_factory=list)
     verifications: List[VerificationResult] = Field(default_factory=list)
     notes: List[str] = Field(default_factory=list)
     role_skill_tags: List[str] = Field(default_factory=list)

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -97,7 +97,11 @@ class InterviewState:
         else:
             self.theory_index = 0
             self.theory_skill_index += 1
-            skills = self.packet.skill_hooks or self.packet.jd_core_skills
+            skills = (
+                self.packet.followup_hooks
+                or self.packet.skill_hooks
+                or self.packet.jd_core_skills
+            )
             if self.theory_skill_index >= len(skills):
                 self.advance_phase()
 

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -30,13 +30,13 @@ async def test_run_interview_end_to_end(monkeypatch):
             if "team_size" in system_prompt:
                 return {"role": "lead", "team_size": "5"}
             if "architecture" in system_prompt:
-                return {"architecture": "svc", "key_technologies": ["python"]}
+                return {"architecture": "svc", "key_technologies": ["python"], "followup_hooks": ["redis"]}
             if "constraints" in system_prompt and "list" in system_prompt:
                 return {"constraints": ["latency"]}
             if "hardest_challenge" in system_prompt or "challenge" in system_prompt:
                 return {"hardest_challenge": "scaling"}
             if "outcomes" in system_prompt or "metrics" in system_prompt:
-                return {"outcomes": "100rps"}
+                return {"outcomes": "100rps", "evaluation_metrics": {"throughput": "100rps"}}
             if "lessons" in system_prompt or "reflection" in system_prompt:
                 return {"lessons": "tests"}
             return {"goal": "demo"}
@@ -44,6 +44,8 @@ async def test_run_interview_end_to_end(monkeypatch):
             return {
                 "skill_hooks": ["python"],
                 "notes": ["api work"],
+                "evaluation_metrics": {"latency": "100ms"},
+                "followup_hooks": ["redis"],
             }
         if task_name == "question_generation":
             return {"question_text": "components?"}

--- a/services/tests/test_flow.py
+++ b/services/tests/test_flow.py
@@ -26,6 +26,8 @@ async def test_run_interview_flow(monkeypatch):
             return {
                 "skill_hooks": ["python", "db"],
                 "notes": ["api work"],
+                "evaluation_metrics": {"latency": "100ms"},
+                "followup_hooks": ["redis"],
             }
         if task_name == "stage_3_question":
             if "python" in system_prompt:
@@ -51,14 +53,14 @@ async def test_run_interview_flow(monkeypatch):
 
     assert result.project_context.goal == "demo"
     assert result.skill_hooks == ["python", "db"]
-    assert [v.skill for v in result.verifications] == ["python", "db"]
+    assert result.followup_hooks == ["redis"]
+    assert result.project_context.evaluation_metrics == {"latency": "100ms"}
+    assert [v.skill for v in result.verifications] == ["redis"]
     assert call_order == [
         "stage_0_analysis",
         "stage_1_parse",
         "stage_1_parse",
         "stage_2_parse",
-        "stage_3_question",
-        "stage_3_eval",
         "stage_3_question",
         "stage_3_eval",
         "stage_4_summary",


### PR DESCRIPTION
## Summary
- Track `evaluation_metrics` and `followup_hooks` in project context and evidence outputs
- Parse technology hooks and metrics during warm-up and evidence stages
- Use `packet.followup_hooks` in later question generation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c38e4a55b48328887df2461fc4104f