### PR TITLE
Expand skill inventory for Stage 0 tagging

### DIFF
--- a/services/common/skill_inventory.py
+++ b/services/common/skill_inventory.py
@@ -1,1 +1,35 @@
-SKILL_INVENTORY = {"backend": ["scaling", "caching"], "frontend": ["state management"]}
+"""Canonical skill tags keyed by role.
+
+These curated tags act as a bootstrap during Stage 0 of the interview flow.
+They provide a starting point for the LLM to reason about relevant topics even
+before analyzing the job description or resume. The tags are intentionally
+high level and non-exhaustive; additional tags will be discovered at runtime
+and merged with these canonical ones.
+"""
+
+SKILL_INVENTORY = {
+    # Backend engineers often need to reason about systems level concerns.
+    "backend": [
+        "scaling",
+        "caching",
+    ],
+    # Frontend work emphasises user interfaces and state handling.
+    "frontend": [
+        "state management",
+        "responsive design",
+        "component architecture",
+    ],
+    # Operational roles focus on deploying and maintaining services.
+    "devops": [
+        "ci/cd",
+        "containerization",
+        "monitoring",
+    ],
+    # Data science and ML oriented roles.
+    "data_science": [
+        "model training",
+        "feature engineering",
+        "data visualization",
+    ],
+}
+


### PR DESCRIPTION
## Summary
- add docstring and curated canonical tags for backend, frontend, devops, and data science roles
- Stage 0 uses these canonical tags and calls the Gateway to refine/extend role skills

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c391a8212483289c3d0f63ff5b994d