### PR TITLE
Handle theory follow-ups with result tracking

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -570,7 +570,7 @@ async def evidence_tradeoff_reflection(
     return None
 
 
-async def theory_primary(
+async def theory_primary_question(
     packet: ContextPacket, skill: str, answer: Optional[str] = None
 ) -> Optional[dict]:
     """Stage-3 step: ask a primary theory question for a skill."""
@@ -587,27 +587,42 @@ async def theory_primary(
     return None
 
 
-async def theory_follow_up(
+async def theory_followup_question(
     packet: ContextPacket, skill: str, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Stage-3 step: follow-up question on the same skill."""
+    """Stage-3 step: follow-up question on the same skill.
+
+    The difficulty of the follow-up is based on the prior verification result.
+    """
 
     if answer is None:
-        system_prompt = (
-            f"You are verifying understanding of '{skill}'. Ask one concise follow-up question. "
-            'Respond with JSON {"question_text": string}.'
+        last = next(
+            (v for v in reversed(packet.verifications) if v.skill == skill),
+            None,
         )
+        if last and last.result == "pass":
+            system_prompt = (
+                f"You are verifying advanced understanding of '{skill}'. "
+                "Ask a harder follow-up question. Respond with JSON {\"question_text\": string}."
+            )
+        else:
+            rationale = last.rationale if last else ""
+            system_prompt = (
+                f"You are verifying understanding of '{skill}'. The candidate's previous answer was incorrect. "
+                f"Reference: {rationale}. Ask a follow-up question to address the misunderstanding. "
+                "Respond with JSON {\"question_text\": string}."
+            )
         data = await gateway.execute_task(
             task_name="stage_3_question",
             system_prompt=system_prompt,
         )
         _decrement_time(packet, 1)
-        return {"question_text": data["question_text"], "question_type": "theory_follow_up"}
+        return {"question_text": data["question_text"], "question_type": "theory_followup"}
 
     e_out = await _theory_eval(TheoryEvalInput(answer=answer))
-    packet.verifications.append(
-        VerificationResult(skill=skill, result=e_out.result, rationale=e_out.rationale)
-    )
+    if packet.verifications:
+        packet.verifications[-1].followup_result = e_out.result
+        packet.verifications[-1].followup_rationale = e_out.rationale
     return None
 
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -15,8 +15,8 @@ from .llm_api import (
     evidence_decision_rationale,
     evidence_outcome_validation,
     evidence_tradeoff_reflection,
-    theory_primary,
-    theory_follow_up,
+    theory_primary_question,
+    theory_followup_question,
     wrapup_candidate_questions,
     wrapup_feedback,
 )
@@ -106,8 +106,8 @@ class Orchestrator:
             step = state.current_theory_step
             skill = skills[state.theory_skill_index]
             func_map = {
-                "primary": theory_primary,
-                "follow_up": theory_follow_up,
+                "primary": theory_primary_question,
+                "followup": theory_followup_question,
             }
             q = await func_map[step](packet, skill, answer)
             if q is None:

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -93,6 +93,8 @@ class VerificationResult(BaseModel):
     skill: str
     result: str
     rationale: Optional[str] = None
+    followup_result: Optional[str] = None
+    followup_rationale: Optional[str] = None
 
 
 class EvidenceOutput(BaseModel):

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -27,7 +27,7 @@ class InterviewState:
     ]
     theory_steps: List[str] = [
         "primary",
-        "follow_up",
+        "followup",
     ]
     wrapup_steps: List[str] = [
         "candidate_questions",

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -103,7 +103,7 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q13["question_type"] == "theory_primary"
 
     q14 = await orch.loop(state, "A language")
-    assert q14["question_type"] == "theory_follow_up"
+    assert q14["question_type"] == "theory_followup"
 
     q15 = await orch.loop(state, "deeper answer")
     assert q15["question_type"] == "wrapup_candidate_questions"


### PR DESCRIPTION
## Summary
- Track theory question sub-steps (`primary`, `followup`) in interview state
- Split theory checking into primary and adaptive follow-up questions that record additional results
- Loop orchestrator through theory steps using new question functions and extended verification schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c392df5f188328b5ea2389df6b6f75