### PR TITLE
Add keyword-triggered follow-up probes

### DIFF
--- a/services/orchestrator_service/followups.py
+++ b/services/orchestrator_service/followups.py
@@ -1,0 +1,51 @@
+"""Keyword-based follow-up question templates.
+
+Provides helper utilities to detect technology keywords in
+candidate answers and to generate targeted follow-up questions.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .schemas import ContextPacket
+
+# Mapping from lowercase keyword to question template. The template may
+# reference ``{keyword}`` to inject the matched term.
+FOLLOWUP_TEMPLATES: Dict[str, str] = {
+    "kafka": "You mentioned Kafka earlier. How did you use Kafka in the project?",
+    "kubernetes": "You mentioned Kubernetes. What challenges did you face managing deployments on Kubernetes?",
+}
+
+
+def extract_followup_hooks(text: str) -> List[str]:
+    """Return list of keywords found in ``text`` matching templates."""
+    lowered = text.lower()
+    return [k for k in FOLLOWUP_TEMPLATES if k in lowered]
+
+
+def build_followup_question(keyword: str) -> str | None:
+    """Create a follow-up question for the given keyword.
+
+    Parameters
+    ----------
+    keyword: str
+        The matched technology keyword.
+
+    Returns
+    -------
+    str | None
+        A formatted follow-up question or ``None`` if no template exists.
+    """
+    template = FOLLOWUP_TEMPLATES.get(keyword.lower())
+    if not template:
+        return None
+    return template.format(keyword=keyword)
+
+
+def update_followup_hooks(packet: ContextPacket, answer: str) -> None:
+    """Scan ``answer`` for keywords and append to packet hooks."""
+    for hook in extract_followup_hooks(answer):
+        if hook not in packet.followup_hooks:
+            packet.followup_hooks.append(hook)
+        if hook not in packet.project_context.followup_hooks:
+            packet.project_context.followup_hooks.append(hook)

--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -46,6 +46,7 @@ from .programs.stage4_wrapup import (
     WrapUpInput,
 )
 from .flow import build_interview_graph
+from .followups import update_followup_hooks
 
 
 
@@ -300,6 +301,7 @@ async def warmup_select_project(
         user_prompt=answer,
     )
     packet.selected_project = data.get("project_name")
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -323,6 +325,7 @@ async def warmup_role_context(
     data = await WarmupRoleProgram()(WarmupRoleInput(answer=answer))
     packet.project_context.role = data.role
     packet.project_context.team_size = data.team_size
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -348,6 +351,7 @@ async def warmup_architecture(
     packet.project_context.key_technologies = data.key_technologies
     packet.project_context.followup_hooks = data.followup_hooks
     packet.followup_hooks.extend(h for h in data.followup_hooks if h not in packet.followup_hooks)
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -370,6 +374,7 @@ async def warmup_constraints(
 
     data = await WarmupConstraintsProgram()(WarmupConstraintsInput(answer=answer))
     packet.project_context.constraints = data.constraints
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -392,6 +397,7 @@ async def warmup_challenge(
 
     data = await WarmupChallengeProgram()(WarmupChallengeInput(answer=answer))
     packet.project_context.hardest_challenge = data.hardest_challenge
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -415,6 +421,7 @@ async def warmup_outcome(
     data = await WarmupOutcomeProgram()(WarmupOutcomeInput(answer=answer))
     packet.project_context.outcomes = data.outcomes
     packet.project_context.evaluation_metrics = data.evaluation_metrics
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -437,6 +444,7 @@ async def warmup_reflection(
 
     data = await WarmupReflectionProgram()(WarmupReflectionInput(answer=answer))
     packet.project_context.lessons = data.lessons
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -459,6 +467,7 @@ async def evidence_components(
         return {"question_text": data["question_text"], "question_type": "evidence_components"}
 
     packet.notes.append(f"Components: {answer}")
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -486,6 +495,7 @@ async def evidence_choice_space(
         user_prompt=answer,
     )
     packet.notes.extend([f"Choice space: {n}" for n in data.get("notes", [])])
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -513,6 +523,7 @@ async def evidence_decision_rationale(
         user_prompt=answer,
     )
     packet.notes.extend([f"Rationale: {n}" for n in data.get("notes", [])])
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -540,6 +551,7 @@ async def evidence_outcome_validation(
         user_prompt=answer,
     )
     packet.notes.extend([f"Outcome: {n}" for n in data.get("notes", [])])
+    update_followup_hooks(packet, answer)
     return None
 
 
@@ -567,6 +579,7 @@ async def evidence_tradeoff_reflection(
         user_prompt=answer,
     )
     packet.notes.extend([f"Trade-offs: {n}" for n in data.get("notes", [])])
+    update_followup_hooks(packet, answer)
     return None
 
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -20,6 +20,7 @@ from .llm_api import (
     wrapup_candidate_questions,
     wrapup_feedback,
 )
+from .followups import build_followup_question
 from session_service.question_log_db import log_question_response
 
 
@@ -31,6 +32,33 @@ class Orchestrator:
     ) -> Optional[dict]:
         packet = state.packet
         phase = state.current_phase
+
+        # Handle answer to a targeted follow-up probe
+        if answer is not None and getattr(state, "last_question_type", None) == "targeted_followup":
+            log_question_response(
+                stage=phase,
+                question_type="targeted_followup",
+                question_text=getattr(state, "last_question_text", ""),
+                answer_text=answer,
+                session_id=getattr(state, "session_id", None),
+                candidate_id=getattr(state, "candidate_id", None),
+            )
+            return await self.decide_next_action(state, None)
+
+        # Insert targeted follow-up questions when hooks are present
+        if answer is None:
+            pending = [
+                h
+                for h in packet.followup_hooks
+                if h not in state.probed_followup_hooks
+            ]
+            for hook in pending:
+                q_text = build_followup_question(hook)
+                state.probed_followup_hooks.add(hook)
+                if q_text:
+                    state.last_question_text = q_text
+                    state.last_question_type = "targeted_followup"
+                    return {"question_text": q_text, "question_type": "targeted_followup"}
 
         if phase == "warm_up":
             if answer is not None and getattr(state, "last_question_text", None):

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -55,6 +55,7 @@ class InterviewState:
         # Track the last question asked to pair with the next answer
         self.last_question_text: Optional[str] = None
         self.last_question_type: Optional[str] = None
+        self.probed_followup_hooks: set[str] = set()
 
 
     @property

--- a/services/tests/test_followups.py
+++ b/services/tests/test_followups.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from orchestrator_service import llm_api as ai
+from orchestrator_service.orchestrator import Orchestrator
+from session_service.interview_state import InterviewState
+
+
+@pytest.mark.asyncio
+async def test_keyword_followup_injected(monkeypatch):
+    qgen_iter = iter([
+        {"question_text": "project?"},
+        {"question_text": "role?"},
+        {"question_text": "architecture?"},
+        {"question_text": "constraints?"},
+    ])
+    parse_iter = iter([
+        {"project_name": "demo"},
+        {"role": "lead", "team_size": "5"},
+        {"architecture": "svc", "key_technologies": ["python"], "followup_hooks": []},
+    ])
+
+    async def fake_execute(task_name, system_prompt, user_prompt=None):
+        if task_name == "stage_0_analysis":
+            return {
+                "role_from_jd": "backend",
+                "jd_core_skills": [],
+                "resume_claims": [],
+                "overlap_skills": [],
+                "primary_overlap_focus": "backend",
+            }
+        if task_name == "skill_tag_refinement":
+            return {"tags": []}
+        if task_name == "question_generation":
+            return next(qgen_iter)
+        if task_name == "stage_1_parse":
+            return next(parse_iter)
+        raise AssertionError(task_name)
+
+    monkeypatch.setattr(ai.gateway, "execute_task", fake_execute)
+
+    packet = await ai.analyze_jd_resume("JD", "Resume")
+    state = InterviewState(packet)
+    orch = Orchestrator()
+
+    q1 = await orch.loop(state)
+    assert q1["question_type"] == "warmup_project"
+
+    q2 = await orch.loop(state, "demo project")
+    assert q2["question_type"] == "warmup_role"
+
+    q3 = await orch.loop(state, "lead of 5")
+    assert q3["question_type"] == "warmup_architecture"
+
+    q4 = await orch.loop(state, "svc using Kafka")
+    assert q4["question_type"] == "targeted_followup"
+    assert "Kafka" in q4["question_text"]
+
+    q5 = await orch.loop(state, "details about kafka")
+    assert q5["question_type"] == "warmup_constraints"


### PR DESCRIPTION
## Summary
- Introduce `followups.py` with templates mapping tech keywords like Kafka and Kubernetes to targeted questions
- Scan warm-up and evidence answers for these keywords to update `ContextPacket.followup_hooks`
- Before each new question, insert targeted follow-up probes when matching hooks are present
- Add tests to verify follow-up insertion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4092ff1fc8328b336f9ce2525a84e