### PR TITLE
Simplify wrap-up phase with closing message

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -648,27 +648,6 @@ async def theory_followup_question(
     return None
 
 
-async def wrapup_candidate_questions(
-    packet: ContextPacket, answer: Optional[str] = None
-) -> Optional[dict]:
-    """Stage-4 step: invite candidate questions about the role or team."""
-
-    if answer is None:
-        notes = "; ".join(packet.notes)
-        system_prompt = (
-            "You are an AI technical interviewer wrapping up the conversation. Based on these notes from the interview, ask the candidate in one short sentence if they have any questions about the role, team, or company. "
-            f"Notes: {notes}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
-        )
-        data = await gateway.execute_task(
-            task_name="question_generation",
-            system_prompt=system_prompt,
-        )
-        _decrement_time(packet, 1)
-        return {"question_text": data["question_text"], "question_type": "wrapup_candidate_questions"}
-
-    packet.notes.append(f"Candidate questions: {answer}")
-    return None
-
 
 async def wrapup_feedback(
     packet: ContextPacket, answer: Optional[str] = None
@@ -697,6 +676,23 @@ async def wrapup_feedback(
         packet.notes.append("Follow-ups: " + ", ".join(out.follow_ups))
     packet.time_remaining_min = 0
     return None
+
+
+async def wrapup_closing(packet: ContextPacket) -> dict:
+    """Stage-4 step: deliver a brief thank-you closing message."""
+
+    notes = "; ".join(packet.notes)
+    system_prompt = (
+        "You are an AI technical interviewer concluding the interview. "
+        "Craft a short thank-you message summarizing the session using these notes. "
+        "Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        f" Notes: {notes}."
+    )
+    data = await gateway.execute_task(
+        task_name="question_generation",
+        system_prompt=system_prompt,
+    )
+    return {"question_text": data["question_text"], "question_type": "wrapup_closing"}
 
 
 async def run_interview(packet: ContextPacket) -> ContextPacket:

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -17,8 +17,8 @@ from .llm_api import (
     evidence_tradeoff_reflection,
     theory_primary_question,
     theory_followup_question,
-    wrapup_candidate_questions,
     wrapup_feedback,
+    wrapup_closing,
 )
 from .followups import build_followup_question, update_followup_hooks
 from session_service.question_log_db import log_question_response
@@ -154,9 +154,21 @@ class Orchestrator:
                 return None
             step = state.current_wrapup_step
             func_map = {
-                "candidate_questions": wrapup_candidate_questions,
                 "feedback": wrapup_feedback,
+                "closing": wrapup_closing,
             }
+            if step == "closing":
+                q = await func_map[step](packet)
+                log_question_response(
+                    stage=phase,
+                    question_type=step,
+                    question_text=q.get("question_text", ""),
+                    answer_text="",
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
+                state.advance_wrapup_step()
+                return q
             q = await func_map[step](packet, answer)
             if answer is not None and getattr(state, "last_question_text", None):
                 log_question_response(

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -30,8 +30,8 @@ class InterviewState:
         "followup",
     ]
     wrapup_steps: List[str] = [
-        "candidate_questions",
         "feedback",
+        "closing",
     ]
 
     def __init__(

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -106,12 +106,12 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q14["question_type"] == "theory_followup"
 
     q15 = await orch.loop(state, "deeper answer")
-    assert q15["question_type"] == "wrapup_candidate_questions"
+    assert q15["question_type"] == "wrapup_feedback"
 
-    q16 = await orch.loop(state, "No questions")
-    assert q16["question_type"] == "wrapup_feedback"
+    q16 = await orch.loop(state, "All good")
+    assert q16["question_type"] == "wrapup_closing"
 
-    q17 = await orch.loop(state, "All good")
+    q17 = await orch.loop(state)
     assert q17 is None
     assert state.packet.time_remaining_min == 0
 


### PR DESCRIPTION
## Summary
- Switch wrap-up sequence to `feedback` followed by `closing`
- Replace candidate questions with final thank-you message generator
- Update orchestrator mapping to handle feedback and closing steps
- Adjust end-to-end test for new wrap-up flow

## Testing
- `pytest services/tests/test_end_to_end.py::test_run_interview_end_to_end -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4326401f883288c645ad5ce6a8dbd