### PR TITLE
Document empty answer logging

### DIFF
--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -159,6 +159,7 @@ class Orchestrator:
             }
             if step == "closing":
                 q = await func_map[step](packet)
+                # Log the final closing prompt even though no answer is expected
                 log_question_response(
                     stage=phase,
                     question_type=step,

--- a/services/session_service/question_log_db.py
+++ b/services/session_service/question_log_db.py
@@ -37,7 +37,11 @@ def log_question_response(
     candidate_id: Optional[str] = None,
     db_path: Path = DB_PATH,
 ) -> None:
-    """Persist a single question/answer pair to the log database."""
+    """Persist a single question/answer pair to the log database.
+
+    ``answer_text`` may be an empty string for prompts that do not expect a
+    response (e.g., closing messages).
+    """
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     cur.execute(


### PR DESCRIPTION
## Summary
- clarify in `log_question_response` that empty answers are allowed
- note in orchestrator that closing prompts are logged with empty answers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44b096e308328b7ca7b2e1c323366