### PR TITLE
Clean question generation fallback output

### DIFF
--- a/services/gateway_service/ai_gateway.py
+++ b/services/gateway_service/ai_gateway.py
@@ -206,7 +206,7 @@ class AIGateway:
 
         # Best-effort fallback for simple question tasks
         if task_name == "question_generation":
-            return {"question_text": content.strip()}
+            return {"question_text": self._clean_text(content).strip()}
 
         # Graceful fallbacks for structured tasks when providers emit non-JSON text
         if task_name == "blueprint_generation":


### PR DESCRIPTION
## Summary
- Ensure question generation fallback strips provider artifacts using `_clean_text`
- Return sanitized question text for question generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c46634cbb0832881dae21451e87fd9