### PR TITLE
Expand warm-up interview steps and helpers

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -23,6 +23,8 @@ from .programs.stage0_analysis import (
     JDResumeAnalysisInput,
 )
 from .programs.stage1_warmup import (
+    WarmupOverviewProgram,
+    WarmupOverviewInput,
     WarmupRoleProgram,
     WarmupRoleInput,
     WarmupArchitectureProgram,
@@ -313,15 +315,40 @@ async def warmup_select_project(
     update_followup_hooks(packet, answer)
     return None
 
-
-async def warmup_role_context(
+async def warmup_project_overview(
     packet: ContextPacket, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Warm-up step: capture role and team size."""
+    """Warm-up step: capture a brief project overview."""
 
     if answer is None:
         system_prompt = (
-            "You are an AI technical interviewer. Ask the candidate, in one concise sentence, to state their role and team size on the project "
+            "You are an AI technical interviewer. Ask the candidate for a one-sentence overview of the project "
+            f"{packet.selected_project}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "warmup_project_overview"}
+
+    data = await WarmupOverviewProgram()(WarmupOverviewInput(answer=answer))
+    if data.goal:
+        packet.project_context.goal = data.goal
+    if data.constraints:
+        packet.project_context.constraints = data.constraints
+    update_followup_hooks(packet, answer)
+    return None
+
+
+async def warmup_role(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: capture the candidate's role."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate to state their role on the project "
             f"{packet.selected_project}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
@@ -333,6 +360,28 @@ async def warmup_role_context(
 
     data = await WarmupRoleProgram()(WarmupRoleInput(answer=answer))
     packet.project_context.role = data.role
+    update_followup_hooks(packet, answer)
+    return None
+
+
+async def warmup_team_size(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: capture the team size."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate how many people worked with them on the project "
+            f"{packet.selected_project}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "warmup_team_size"}
+
+    data = await WarmupRoleProgram()(WarmupRoleInput(answer=answer))
     packet.project_context.team_size = data.team_size
     update_followup_hooks(packet, answer)
     return None
@@ -341,11 +390,11 @@ async def warmup_role_context(
 async def warmup_architecture(
     packet: ContextPacket, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Warm-up step: high-level architecture and technologies."""
+    """Warm-up step: describe high-level architecture."""
 
     if answer is None:
         system_prompt = (
-            "You are an AI technical interviewer. Ask the candidate to briefly describe the high-level architecture and key technologies of their project "
+            "You are an AI technical interviewer. Ask the candidate to briefly describe the high-level architecture of the project "
             f"{packet.selected_project} in one sentence. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
@@ -357,6 +406,28 @@ async def warmup_architecture(
 
     data = await WarmupArchitectureProgram()(WarmupArchitectureInput(answer=answer))
     packet.project_context.architecture = data.architecture
+    update_followup_hooks(packet, answer)
+    return None
+
+
+async def warmup_tech_stack(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: capture key technologies used."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate to list the main technologies or tools used on the project "
+            f"{packet.selected_project}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "warmup_tech_stack"}
+
+    data = await WarmupArchitectureProgram()(WarmupArchitectureInput(answer=answer))
     packet.project_context.key_technologies = data.key_technologies
     packet.project_context.followup_hooks = data.followup_hooks
     packet.followup_hooks.extend(h for h in data.followup_hooks if h not in packet.followup_hooks)
@@ -395,7 +466,7 @@ async def warmup_challenge(
     if answer is None:
         system_prompt = (
             "You are an AI technical interviewer. Ask the candidate to describe, in one sentence, the toughest technical challenge they faced on the project "
-            f"{packet.selected_project} and how they addressed it. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+            f"{packet.selected_project}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
             task_name="question_generation",
@@ -406,6 +477,28 @@ async def warmup_challenge(
 
     data = await WarmupChallengeProgram()(WarmupChallengeInput(answer=answer))
     packet.project_context.hardest_challenge = data.hardest_challenge
+    update_followup_hooks(packet, answer)
+    return None
+
+
+async def warmup_resolution(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Warm-up step: how the challenge was resolved."""
+
+    if answer is None:
+        system_prompt = (
+            "You are an AI technical interviewer. Ask the candidate, in one sentence, how they addressed that challenge on the project "
+            f"{packet.selected_project}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "warmup_resolution"}
+
+    packet.notes.append(f"Challenge resolution: {answer}")
     update_followup_hooks(packet, answer)
     return None
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -4,10 +4,14 @@ from typing import Any, Optional
 
 from .llm_api import (
     warmup_select_project,
-    warmup_role_context,
+    warmup_project_overview,
+    warmup_role,
+    warmup_team_size,
     warmup_architecture,
+    warmup_tech_stack,
     warmup_constraints,
     warmup_challenge,
+    warmup_resolution,
     warmup_outcome,
     warmup_reflection,
     evidence_components,
@@ -76,10 +80,14 @@ class Orchestrator:
             step = state.current_warmup_step
             func_map = {
                 "select_project": warmup_select_project,
-                "role_context": warmup_role_context,
+                "project_overview": warmup_project_overview,
+                "role": warmup_role,
+                "team_size": warmup_team_size,
                 "architecture": warmup_architecture,
+                "tech_stack": warmup_tech_stack,
                 "constraints": warmup_constraints,
                 "challenge": warmup_challenge,
+                "resolution": warmup_resolution,
                 "outcome": warmup_outcome,
                 "reflection": warmup_reflection,
             }

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -11,10 +11,14 @@ class InterviewState:
     phases: List[str] = ["warm_up", "evidence", "theory", "wrap_up"]
     warmup_steps: List[str] = [
         "select_project",
-        "role_context",
+        "project_overview",
+        "role",
+        "team_size",
         "architecture",
+        "tech_stack",
         "constraints",
         "challenge",
+        "resolution",
         "outcome",
         "reflection",
     ]

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -27,10 +27,17 @@ async def test_run_interview_end_to_end(monkeypatch):
         if task_name == "stage_1_parse":
             if "project name" in system_prompt:
                 return {"project_name": "demo"}
-            if "team_size" in system_prompt:
-                return {"role": "lead", "team_size": "5"}
+            if "goal" in system_prompt:
+                return {"goal": "demo", "constraints": []}
+            if "role and team_size" in system_prompt:
+                if "Lead" in (user_prompt or ""):
+                    return {"role": "lead", "team_size": None}
+                if "5" in (user_prompt or ""):
+                    return {"role": None, "team_size": "5"}
             if "architecture" in system_prompt:
-                return {"architecture": "svc", "key_technologies": ["python"], "followup_hooks": ["redis"]}
+                if "svc" in (user_prompt or ""):
+                    return {"architecture": "svc", "key_technologies": [], "followup_hooks": []}
+                return {"architecture": None, "key_technologies": ["python"], "followup_hooks": ["redis"]}
             if "constraints" in system_prompt and "list" in system_prompt:
                 return {"constraints": ["latency"]}
             if "hardest_challenge" in system_prompt or "challenge" in system_prompt:
@@ -67,51 +74,63 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q1["question_type"] == "warmup_project"
 
     q2 = await orch.loop(state, "demo project")
-    assert q2["question_type"] == "warmup_role"
+    assert q2["question_type"] == "warmup_project_overview"
 
-    q3 = await orch.loop(state, "Lead of team 5")
-    assert q3["question_type"] == "warmup_architecture"
+    q3 = await orch.loop(state, "overview")
+    assert q3["question_type"] == "warmup_role"
 
-    q4 = await orch.loop(state, "svc using python")
-    assert q4["question_type"] == "warmup_constraints"
+    q4 = await orch.loop(state, "Lead")
+    assert q4["question_type"] == "warmup_team_size"
 
-    q5 = await orch.loop(state, "latency under 100ms")
-    assert q5["question_type"] == "warmup_challenge"
+    q5 = await orch.loop(state, "Team of 5")
+    assert q5["question_type"] == "warmup_architecture"
 
-    q6 = await orch.loop(state, "scaling issues")
-    assert q6["question_type"] == "warmup_outcome"
+    q6 = await orch.loop(state, "svc architecture")
+    assert q6["question_type"] == "warmup_tech_stack"
 
-    q7 = await orch.loop(state, "100rps")
-    assert q7["question_type"] == "warmup_reflection"
+    q7 = await orch.loop(state, "python and redis")
+    assert q7["question_type"] == "warmup_constraints"
 
-    q8 = await orch.loop(state, "better tests")
-    assert q8["question_type"] == "evidence_components"
+    q8 = await orch.loop(state, "latency under 100ms")
+    assert q8["question_type"] == "warmup_challenge"
 
-    q9 = await orch.loop(state, "component details")
-    assert q9["question_type"] == "evidence_choice_space"
+    q9 = await orch.loop(state, "scaling issues")
+    assert q9["question_type"] == "warmup_resolution"
 
-    q10 = await orch.loop(state, "considered options")
-    assert q10["question_type"] == "evidence_decision_rationale"
+    q10 = await orch.loop(state, "used caching")
+    assert q10["question_type"] == "warmup_outcome"
 
-    q11 = await orch.loop(state, "selected because")
-    assert q11["question_type"] == "evidence_outcome_validation"
+    q11 = await orch.loop(state, "100rps")
+    assert q11["question_type"] == "warmup_reflection"
 
-    q12 = await orch.loop(state, "it worked")
-    assert q12["question_type"] == "evidence_tradeoff_reflection"
+    q12 = await orch.loop(state, "better tests")
+    assert q12["question_type"] == "evidence_components"
 
-    q13 = await orch.loop(state, "tradeoffs considered")
-    assert q13["question_type"] == "theory_primary"
+    q13 = await orch.loop(state, "component details")
+    assert q13["question_type"] == "evidence_choice_space"
 
-    q14 = await orch.loop(state, "A language")
-    assert q14["question_type"] == "theory_followup"
+    q14 = await orch.loop(state, "considered options")
+    assert q14["question_type"] == "evidence_decision_rationale"
 
-    q15 = await orch.loop(state, "deeper answer")
-    assert q15["question_type"] == "wrapup_feedback"
+    q15 = await orch.loop(state, "selected because")
+    assert q15["question_type"] == "evidence_outcome_validation"
 
-    q16 = await orch.loop(state, "All good")
-    assert q16["question_type"] == "wrapup_closing"
+    q16 = await orch.loop(state, "it worked")
+    assert q16["question_type"] == "evidence_tradeoff_reflection"
 
-    q17 = await orch.loop(state)
-    assert q17 is None
+    q17 = await orch.loop(state, "tradeoffs considered")
+    assert q17["question_type"] == "theory_primary"
+
+    q18 = await orch.loop(state, "A language")
+    assert q18["question_type"] == "theory_followup"
+
+    q19 = await orch.loop(state, "deeper answer")
+    assert q19["question_type"] == "wrapup_feedback"
+
+    q20 = await orch.loop(state, "All good")
+    assert q20["question_type"] == "wrapup_closing"
+
+    q21 = await orch.loop(state)
+    assert q21 is None
     assert state.packet.time_remaining_min == 0
 

--- a/services/tests/test_followups.py
+++ b/services/tests/test_followups.py
@@ -7,26 +7,13 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from orchestrator_service import llm_api as ai
 from orchestrator_service.orchestrator import Orchestrator
-from session_service.interview_state import InterviewState\
-
+from session_service.interview_state import InterviewState
 from orchestrator_service.schemas import ContextPacket
 
 
 
 @pytest.mark.asyncio
 async def test_keyword_followup_injected(monkeypatch):
-    qgen_iter = iter([
-        {"question_text": "project?"},
-        {"question_text": "role?"},
-        {"question_text": "architecture?"},
-        {"question_text": "constraints?"},
-    ])
-    parse_iter = iter([
-        {"project_name": "demo"},
-        {"role": "lead", "team_size": "5"},
-        {"architecture": "svc", "key_technologies": ["python"], "followup_hooks": []},
-    ])
-
     async def fake_execute(task_name, system_prompt, user_prompt=None):
         if task_name == "stage_0_analysis":
             return {
@@ -39,9 +26,23 @@ async def test_keyword_followup_injected(monkeypatch):
         if task_name == "skill_tag_refinement":
             return {"tags": []}
         if task_name == "question_generation":
-            return next(qgen_iter)
+            return {"question_text": "q"}
         if task_name == "stage_1_parse":
-            return next(parse_iter)
+            if "project name" in system_prompt:
+                return {"project_name": "demo"}
+            if "goal" in system_prompt:
+                return {"goal": "demo", "constraints": []}
+            if "role and team_size" in system_prompt:
+                if "lead" in (user_prompt or "").lower():
+                    return {"role": "lead", "team_size": None}
+                if "5" in (user_prompt or ""):
+                    return {"role": None, "team_size": "5"}
+            if "architecture" in system_prompt:
+                if "svc" in (user_prompt or ""):
+                    return {"architecture": "svc", "key_technologies": [], "followup_hooks": []}
+                return {"architecture": None, "key_technologies": [], "followup_hooks": []}
+            if "constraints" in system_prompt and "list" in system_prompt:
+                return {"constraints": ["latency"]}
         raise AssertionError(task_name)
 
     monkeypatch.setattr(ai.gateway, "execute_task", fake_execute)
@@ -54,21 +55,30 @@ async def test_keyword_followup_injected(monkeypatch):
     assert q1["question_type"] == "warmup_project"
 
     q2 = await orch.loop(state, "demo project")
-    assert q2["question_type"] == "warmup_role"
+    assert q2["question_type"] == "warmup_project_overview"
 
-    q3 = await orch.loop(state, "lead of 5")
-    assert q3["question_type"] == "warmup_architecture"
+    q3 = await orch.loop(state, "overview")
+    assert q3["question_type"] == "warmup_role"
 
-    q4 = await orch.loop(state, "svc using Kafka")
-    assert q4["question_type"] == "targeted_followup"
-    assert "Kafka" in q4["question_text"]
+    q4 = await orch.loop(state, "lead")
+    assert q4["question_type"] == "warmup_team_size"
 
-    q5 = await orch.loop(state, "details about kafka on Kubernetes")
-    assert q5["question_type"] == "targeted_followup"
-    assert "Kubernetes" in q5["question_text"]
+    q5 = await orch.loop(state, "5")
+    assert q5["question_type"] == "warmup_architecture"
 
-    q6 = await orch.loop(state, "k8s follow-up response")
-    assert q6["question_type"] == "warmup_constraints"
+    q6 = await orch.loop(state, "svc")
+    assert q6["question_type"] == "warmup_tech_stack"
+
+    q7 = await orch.loop(state, "Kafka")
+    assert q7["question_type"] == "targeted_followup"
+    assert "Kafka" in q7["question_text"]
+
+    q8 = await orch.loop(state, "details about kafka on Kubernetes")
+    assert q8["question_type"] == "targeted_followup"
+    assert "Kubernetes" in q8["question_text"]
+
+    q9 = await orch.loop(state, "k8s follow-up response")
+    assert q9["question_type"] == "warmup_constraints"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add project overview, separate role/team size, tech stack, and resolution steps to warm-up flow
- Implement new LLM helpers for each warm-up step and update orchestrator mapping and logging
- Adjust tests for expanded sequence and ensure targeted followups align with tech stack step

## Testing
- `pytest services/tests/test_end_to_end.py::test_run_interview_end_to_end -q`
- `pytest services/tests/test_followups.py::test_keyword_followup_injected -q`
- `pytest services/tests/test_followups.py::test_theory_eval_handles_bad_json -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c46907f61c83288b64e115ef1c8971