### PR TITLE
Expand evidence phase component and tradeoff steps

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -550,25 +550,53 @@ async def warmup_reflection(
     return None
 
 
-async def evidence_components(
+async def evidence_components_list(
     packet: ContextPacket, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Stage-2 step: ask about project components owned."""
+    """Stage-2 step: list key project components."""
 
     if answer is None:
         context = _skill_prompt_context(packet)
         system_prompt = (
-            "You are an AI technical interviewer asking the candidate to briefly list 2–3 major components they built on the selected project, noting each component's purpose and main interfaces"
+            "You are an AI technical interviewer asking the candidate to briefly list 2–3 major components they built on the selected project"
             f"{context}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
             task_name="question_generation",
             system_prompt=system_prompt,
         )
-        _decrement_time(packet, 2)
-        return {"question_text": data["question_text"], "question_type": "evidence_components"}
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_components_list"}
 
     packet.notes.append(f"Components: {answer}")
+    update_followup_hooks(packet, answer)
+    return None
+
+
+async def evidence_component_details(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-2 step: detail one component's purpose and interfaces."""
+
+    if answer is None:
+        context = _skill_prompt_context(packet)
+        system_prompt = (
+            "You are an AI technical interviewer asking the candidate to pick one component and briefly describe its purpose and main interfaces"
+            f"{context}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_component_details"}
+
+    data = await gateway.execute_task(
+        task_name="stage_2_parse",
+        system_prompt='Summarize the component\'s purpose and interfaces as short notes. Respond with JSON {"notes": [string]}.' ,
+        user_prompt=answer,
+    )
+    packet.notes.extend([f"Component details: {n}" for n in data.get("notes", [])])
     update_followup_hooks(packet, answer)
     return None
 
@@ -657,15 +685,15 @@ async def evidence_outcome_validation(
     return None
 
 
-async def evidence_tradeoff_reflection(
+async def evidence_tradeoff_exploration(
     packet: ContextPacket, answer: Optional[str] = None
 ) -> Optional[dict]:
-    """Stage-2 step: explore trade-offs or alternative paths."""
+    """Stage-2 step: surface trade-offs or alternatives considered."""
 
     if answer is None:
         context = _skill_prompt_context(packet)
         system_prompt = (
-            "You are an AI technical interviewer asking the candidate to reflect on trade-offs or alternative paths they considered and why those were not chosen"
+            "You are an AI technical interviewer asking the candidate what trade-offs or alternative paths they considered"
             f"{context}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
         )
         data = await gateway.execute_task(
@@ -673,14 +701,42 @@ async def evidence_tradeoff_reflection(
             system_prompt=system_prompt,
         )
         _decrement_time(packet, 1)
-        return {"question_text": data["question_text"], "question_type": "evidence_tradeoff_reflection"}
+        return {"question_text": data["question_text"], "question_type": "evidence_tradeoff_exploration"}
 
     data = await gateway.execute_task(
         task_name="stage_2_parse",
-        system_prompt='Summarize the trade-offs or alternatives mentioned. Respond with JSON {"notes": [string]}.' ,
+        system_prompt='List the trade-offs or alternatives mentioned. Respond with JSON {"notes": [string]}.' ,
         user_prompt=answer,
     )
     packet.notes.extend([f"Trade-offs: {n}" for n in data.get("notes", [])])
+    update_followup_hooks(packet, answer)
+    return None
+
+
+async def evidence_tradeoff_reasoning(
+    packet: ContextPacket, answer: Optional[str] = None
+) -> Optional[dict]:
+    """Stage-2 step: why the chosen approach prevailed."""
+
+    if answer is None:
+        context = _skill_prompt_context(packet)
+        system_prompt = (
+            "You are an AI technical interviewer asking the candidate why the chosen approach prevailed over the alternatives"
+            f"{context}. Respond ONLY with a single, valid JSON object with a single key 'question_text'."
+        )
+        data = await gateway.execute_task(
+            task_name="question_generation",
+            system_prompt=system_prompt,
+        )
+        _decrement_time(packet, 1)
+        return {"question_text": data["question_text"], "question_type": "evidence_tradeoff_reasoning"}
+
+    data = await gateway.execute_task(
+        task_name="stage_2_parse",
+        system_prompt='Summarize the reasoning for the chosen approach. Respond with JSON {"notes": [string]}.' ,
+        user_prompt=answer,
+    )
+    packet.notes.extend([f"Trade-off reasoning: {n}" for n in data.get("notes", [])])
     update_followup_hooks(packet, answer)
     return None
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -14,11 +14,13 @@ from .llm_api import (
     warmup_resolution,
     warmup_outcome,
     warmup_reflection,
-    evidence_components,
+    evidence_components_list,
+    evidence_component_details,
     evidence_choice_space,
     evidence_decision_rationale,
     evidence_outcome_validation,
-    evidence_tradeoff_reflection,
+    evidence_tradeoff_exploration,
+    evidence_tradeoff_reasoning,
     theory_primary_question,
     theory_followup_question,
     wrapup_feedback,
@@ -102,18 +104,20 @@ class Orchestrator:
         if phase == "evidence":
             step = state.current_evidence_step
             func_map = {
-                "components": evidence_components,
+                "components_list": evidence_components_list,
+                "component_details": evidence_component_details,
                 "choice_space": evidence_choice_space,
                 "decision_rationale": evidence_decision_rationale,
                 "outcome_validation": evidence_outcome_validation,
-                "tradeoff_reflection": evidence_tradeoff_reflection,
+                "tradeoff_exploration": evidence_tradeoff_exploration,
+                "tradeoff_reasoning": evidence_tradeoff_reasoning,
             }
             q = await func_map[step](packet, answer)
 
             if answer is not None and getattr(state, "last_question_text", None):
                 log_question_response(
                     stage="evidence",
-                    question_type=step,
+                    question_type=getattr(state, "last_question_type", ""),
                     question_text=getattr(state, "last_question_text", ""),
                     answer_text=answer,
                     session_id=getattr(state, "session_id", None),

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -23,11 +23,13 @@ class InterviewState:
         "reflection",
     ]
     evidence_steps: List[str] = [
-        "components",
+        "components_list",
+        "component_details",
         "choice_space",
         "decision_rationale",
         "outcome_validation",
-        "tradeoff_reflection",
+        "tradeoff_exploration",
+        "tradeoff_reasoning",
     ]
     theory_steps: List[str] = [
         "primary",

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -104,33 +104,39 @@ async def test_run_interview_end_to_end(monkeypatch):
     assert q11["question_type"] == "warmup_reflection"
 
     q12 = await orch.loop(state, "better tests")
-    assert q12["question_type"] == "evidence_components"
+    assert q12["question_type"] == "evidence_components_list"
 
-    q13 = await orch.loop(state, "component details")
-    assert q13["question_type"] == "evidence_choice_space"
+    q13 = await orch.loop(state, "listed components")
+    assert q13["question_type"] == "evidence_component_details"
 
-    q14 = await orch.loop(state, "considered options")
-    assert q14["question_type"] == "evidence_decision_rationale"
+    q14 = await orch.loop(state, "component details")
+    assert q14["question_type"] == "evidence_choice_space"
 
-    q15 = await orch.loop(state, "selected because")
-    assert q15["question_type"] == "evidence_outcome_validation"
+    q15 = await orch.loop(state, "considered options")
+    assert q15["question_type"] == "evidence_decision_rationale"
 
-    q16 = await orch.loop(state, "it worked")
-    assert q16["question_type"] == "evidence_tradeoff_reflection"
+    q16 = await orch.loop(state, "selected because")
+    assert q16["question_type"] == "evidence_outcome_validation"
 
-    q17 = await orch.loop(state, "tradeoffs considered")
-    assert q17["question_type"] == "theory_primary"
+    q17 = await orch.loop(state, "it worked")
+    assert q17["question_type"] == "evidence_tradeoff_exploration"
 
-    q18 = await orch.loop(state, "A language")
-    assert q18["question_type"] == "theory_followup"
+    q18 = await orch.loop(state, "tradeoffs considered")
+    assert q18["question_type"] == "evidence_tradeoff_reasoning"
 
-    q19 = await orch.loop(state, "deeper answer")
-    assert q19["question_type"] == "wrapup_feedback"
+    q19 = await orch.loop(state, "why chosen")
+    assert q19["question_type"] == "theory_primary"
 
-    q20 = await orch.loop(state, "All good")
-    assert q20["question_type"] == "wrapup_closing"
+    q20 = await orch.loop(state, "A language")
+    assert q20["question_type"] == "theory_followup"
 
-    q21 = await orch.loop(state)
-    assert q21 is None
+    q21 = await orch.loop(state, "deeper answer")
+    assert q21["question_type"] == "wrapup_feedback"
+
+    q22 = await orch.loop(state, "All good")
+    assert q22["question_type"] == "wrapup_closing"
+
+    q23 = await orch.loop(state)
+    assert q23 is None
     assert state.packet.time_remaining_min == 0
 


### PR DESCRIPTION
## Summary
- Split evidence components into `components_list` and `component_details` steps
- Separate tradeoff reflection into exploration and reasoning helpers
- Update orchestrator mappings, logging, and tests for new question types

## Testing
- `pytest services/tests/test_end_to_end.py::test_run_interview_end_to_end -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47193e2c48328a1a9cb83658c6268