### PR TITLE
Add JSON repair fallback for malformed LLM JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "fpdf2>=2.7.0",
     "dspy-ai>=3.0.0",
     "langgraph>=0.6.7",
+    "json-repair>=0.50.1",
 ]
 
 [project.optional-dependencies]

--- a/services/gateway_service/ai_gateway.py
+++ b/services/gateway_service/ai_gateway.py
@@ -14,6 +14,7 @@ import re
 
 import httpx
 import yaml
+from json_repair import repair_json
 
 from .config import settings
 
@@ -267,6 +268,13 @@ class AIGateway:
             except Exception:
                 pass
 
+        # 4) attempt to repair malformed JSON
+        try:
+            repaired = repair_json(text)
+            return json.loads(repaired)
+        except Exception:
+            pass
+
         return None
 
     @staticmethod
@@ -280,6 +288,8 @@ class AIGateway:
         text = re.sub(r"<\|[^|>]+\|>", " ", text)
         # Remove labels like 'final', 'JSON', 'message' at the start if present
         text = re.sub(r"^(?:\s*(?:final|json|message|output|result)\s*[:\-]?\s*)+", "", text, flags=re.IGNORECASE)
+        # Normalize smart quotes
+        text = text.replace("“", "\"").replace("”", "\"")
         return text.strip()
 
     @staticmethod

--- a/services/tests/test_json_repair.py
+++ b/services/tests/test_json_repair.py
@@ -1,0 +1,9 @@
+from gateway_service.ai_gateway import AIGateway
+
+
+def test_parse_json_with_repair_and_smart_quotes():
+    # Simulate LLM output with smart quotes and trailing comma
+    text = 'final: {“score”: 0.8, “assessed_depth”: “Intermediate”,}'
+    parsed = AIGateway._parse_json_like(text)
+    assert parsed == {"score": 0.8, "assessed_depth": "Intermediate"}
+


### PR DESCRIPTION
## Summary
- Normalize smart quotes in LLM responses and attempt JSON repair when parsing fails
- Add json-repair dependency and regression test

## Testing
- `PYTHONPATH=services pytest services/tests/test_json_repair.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4a282e6fc8328ba60829c7953e061