### PR TITLE
Add intro and focus area QA stages

### DIFF
--- a/services/orchestrator_service/flow.py
+++ b/services/orchestrator_service/flow.py
@@ -5,6 +5,8 @@ from langgraph.graph import StateGraph, START, END
 
 from .schemas import ContextPacket, VerificationResult
 from .programs.stage0_analysis import Stage0AnalysisProgram, JDResumeAnalysisInput
+from .programs.stage1_intro import Stage1IntroProgram, IntroModuleInput
+from .programs.stage2_qa import Stage2QAProgram, Stage2QAInput
 from .programs.stage3_theory import (
     TheoryQuestionProgram,
     TheoryQuestionInput,
@@ -24,6 +26,24 @@ async def stage0_analysis_node(state: InterviewState) -> dict:
         JDResumeAnalysisInput(jd_text=state.jd_text, resume_text=state.resume_text)
     )
     return output.model_dump()
+
+
+async def stage1_intro_node(state: InterviewState) -> dict:
+    """Generate a greeting and capture it for reference."""
+
+    program = Stage1IntroProgram()
+    output = await program(IntroModuleInput(role=state.role_from_jd))
+    return {"notes": state.notes + [output.question_text]}
+
+
+async def stage2_focus_plan_node(state: InterviewState) -> dict:
+    """Request focus areas and questions for the QA stage."""
+
+    program = Stage2QAProgram()
+    output = await program(
+        Stage2QAInput(jd_text=state.jd_text, resume_text=state.resume_text)
+    )
+    return {"focus_areas": output.interview_focus_areas}
 
 
 async def stage3_theory_node(state: InterviewState) -> dict:
@@ -58,11 +78,15 @@ def build_interview_graph() -> StateGraph:
     """Create a sequential LangGraph covering all interview stages."""
     graph = StateGraph(InterviewState)
     graph.add_node("stage0_analysis", stage0_analysis_node)
+    graph.add_node("stage1_intro", stage1_intro_node)
+    graph.add_node("stage2_focus_plan", stage2_focus_plan_node)
     graph.add_node("stage3_theory", stage3_theory_node)
     graph.add_node("stage4_wrapup", stage4_wrapup_node)
 
     graph.add_edge(START, "stage0_analysis")
-    graph.add_edge("stage0_analysis", "stage3_theory")
+    graph.add_edge("stage0_analysis", "stage1_intro")
+    graph.add_edge("stage1_intro", "stage2_focus_plan")
+    graph.add_edge("stage2_focus_plan", "stage3_theory")
 
     def _more_theory(state: InterviewState) -> str:
         skills = state.followup_hooks or state.skill_hooks or state.jd_core_skills

--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -1,6 +1,6 @@
 """Core AI interview utilities."""
 
-from typing import Optional
+from typing import List, Optional
 from types import SimpleNamespace
 
 from .schemas import (
@@ -11,6 +11,8 @@ from .schemas import (
     EvaluationResponse,
     ContextPacket,
     VerificationResult,
+    FocusAreaQuestions,
+    FocusAreaExchange,
 )
 from gateway_service import gateway
 from common.skill_inventory import SKILL_INVENTORY
@@ -22,6 +24,8 @@ from .programs.stage0_analysis import (
     Stage0AnalysisProgram,
     JDResumeAnalysisInput,
 )
+from .programs.stage1_intro import Stage1IntroProgram, IntroModuleInput
+from .programs.stage2_qa import Stage2QAProgram, Stage2QAInput
 from .programs.stage3_theory import (
     TheoryQuestionProgram,
     TheoryQuestionInput,
@@ -194,6 +198,8 @@ _interviewer = LLMInterviewer()
 _monitor = LLMMonitor()
 _scoring = ScoringEngine()
 _stage0 = Stage0AnalysisProgram()
+_intro = Stage1IntroProgram()
+_qa_plan = Stage2QAProgram()
 _theory_question = TheoryQuestionProgram()
 _theory_eval = TheoryEvalProgram()
 _wrap_up = WrapUpProgram()
@@ -213,6 +219,88 @@ def _decrement_time(packet: ContextPacket, minutes: int) -> None:
 
     remaining = packet.time_remaining_min or packet.duration_min
     packet.time_remaining_min = max(remaining - minutes, 0)
+
+
+async def intro_greeting(packet: ContextPacket) -> dict:
+    """Generate the introductory greeting and decrement available time."""
+
+    output = await _intro(IntroModuleInput(role=packet.role_from_jd))
+    _decrement_time(packet, 1)
+    return {"question_text": output.question_text, "question_type": "intro_greeting"}
+
+
+def record_intro_answer(packet: ContextPacket, answer: str) -> None:
+    """Append the candidate's introduction to session notes."""
+
+    if answer:
+        packet.notes.append(f"Candidate introduction: {answer}")
+
+
+async def ensure_focus_area_plan(packet: ContextPacket) -> List[FocusAreaQuestions]:
+    """Fetch or reuse the generated focus areas for the QA module."""
+
+    if packet.focus_areas:
+        return packet.focus_areas
+
+    output = await _qa_plan(
+        Stage2QAInput(jd_text=packet.jd_text, resume_text=packet.resume_text)
+    )
+
+    cleaned: List[FocusAreaQuestions] = []
+    for area in output.interview_focus_areas:
+        name = (area.area_name or "").strip()
+        if not name:
+            continue
+        reasoning = [q.strip() for q in list(area.reasoning_questions or []) if q and q.strip()]
+        conceptual = [
+            q.strip() for q in list(area.conceptual_questions or []) if q and q.strip()
+        ]
+        cleaned.append(
+            FocusAreaQuestions(
+                area_name=name,
+                reasoning_questions=reasoning[:2],
+                conceptual_questions=conceptual[:2],
+            )
+        )
+
+    packet.focus_areas = cleaned
+    return packet.focus_areas
+
+
+def build_focus_area_question(
+    packet: ContextPacket,
+    focus_area: str,
+    question_category: str,
+    question_text: str,
+) -> dict:
+    """Create the payload for a QA question while consuming interview time."""
+
+    normalized_type = f"qa_{question_category}"
+    _decrement_time(packet, 1)
+    return {
+        "question_text": question_text,
+        "question_type": normalized_type,
+        "focus_area": focus_area,
+    }
+
+
+def record_focus_area_answer(
+    packet: ContextPacket,
+    focus_area: str,
+    question_type: str,
+    question_text: str,
+    answer: str,
+) -> None:
+    """Persist a QA turn on the context packet for later evaluation."""
+
+    packet.focus_area_history.append(
+        FocusAreaExchange(
+            area_name=focus_area,
+            question_type=question_type,
+            question_text=question_text,
+            answer_text=answer,
+        )
+    )
 
 
 

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -3,13 +3,18 @@
 from typing import Any, Optional
 
 from .llm_api import (
+    intro_greeting,
+    record_intro_answer,
+    ensure_focus_area_plan,
+    build_focus_area_question,
+    record_focus_area_answer,
     theory_primary_question,
     theory_followup_question,
     wrapup_feedback,
     wrapup_closing,
 )
 from .followups import build_followup_question, update_followup_hooks
-from session_service.question_log_db import log_question_response
+from session_service.question_log_db import log_question_response, log_focus_area_response
 
 
 class Orchestrator:
@@ -53,6 +58,81 @@ class Orchestrator:
                     state.last_question_type = "targeted_followup"
                     state.last_followup_hook = hook
                     return {"question_text": q_text, "question_type": "targeted_followup"}
+
+        if phase == "intro":
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage=phase,
+                    question_type=getattr(state, "last_question_type", ""),
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
+                record_intro_answer(packet, answer)
+                state.last_question_text = None
+                state.last_question_type = None
+                state.advance_phase()
+                return await self.decide_next_action(state, None)
+
+            if answer is None:
+                q_payload = await intro_greeting(packet)
+                state.last_question_text = q_payload.get("question_text")
+                state.last_question_type = q_payload.get("question_type")
+                return q_payload
+
+            state.advance_phase()
+            return await self.decide_next_action(state, None)
+
+        if phase == "qa":
+            if answer is not None and getattr(state, "last_question_text", None):
+                log_question_response(
+                    stage=phase,
+                    question_type=getattr(state, "last_question_type", ""),
+                    question_text=getattr(state, "last_question_text", ""),
+                    answer_text=answer,
+                    session_id=getattr(state, "session_id", None),
+                    candidate_id=getattr(state, "candidate_id", None),
+                )
+                if getattr(state, "last_focus_area", None):
+                    log_focus_area_response(
+                        focus_area=state.last_focus_area,
+                        question_type=getattr(state, "last_question_type", ""),
+                        question_text=getattr(state, "last_question_text", ""),
+                        answer_text=answer,
+                        session_id=getattr(state, "session_id", None),
+                        candidate_id=getattr(state, "candidate_id", None),
+                    )
+                    record_focus_area_answer(
+                        packet,
+                        state.last_focus_area,
+                        getattr(state, "last_question_type", ""),
+                        getattr(state, "last_question_text", ""),
+                        answer,
+                    )
+                state.qa_queue_index += 1
+                state.last_question_text = None
+                state.last_question_type = None
+                state.last_focus_area = None
+
+            focus_areas = await ensure_focus_area_plan(packet)
+            state.ensure_qa_queue(focus_areas)
+
+            if state.qa_queue_index >= len(state.qa_queue):
+                state.advance_phase()
+                return await self.decide_next_action(state, None)
+
+            item = state.qa_queue[state.qa_queue_index]
+            q_payload = build_focus_area_question(
+                packet,
+                item["focus_area"],
+                item["question_type"],
+                item["text"],
+            )
+            state.last_question_text = q_payload.get("question_text")
+            state.last_question_type = q_payload.get("question_type")
+            state.last_focus_area = q_payload.get("focus_area")
+            return q_payload
 
         if phase == "theory":
             if answer is not None and getattr(state, "last_question_text", None):

--- a/services/orchestrator_service/programs/stage1_intro.py
+++ b/services/orchestrator_service/programs/stage1_intro.py
@@ -1,0 +1,42 @@
+"""DSPy program for Stage-1 introductory greeting."""
+from __future__ import annotations
+
+import dspy
+from pydantic import BaseModel, Field
+
+from gateway_service import gateway
+
+
+class IntroModuleInput(BaseModel):
+    """Inputs for tailoring the introductory greeting."""
+
+    role: str | None = Field(default=None, description="Role title inferred from the JD")
+    candidate_name: str | None = Field(
+        default=None, description="Optional candidate name for personalization"
+    )
+
+
+class IntroModuleOutput(BaseModel):
+    """Generated introductory question."""
+
+    question_text: str = Field(..., description="The greeting and introduction request")
+
+
+class Stage1IntroProgram(dspy.Module):
+    """Generate a warm greeting that requests a brief introduction."""
+
+    system_prompt_template: str = (
+        "You are the AI interviewer for a {role} hiring conversation. "
+        "Greet the {candidate} warmly and invite them to briefly tell you about themselves. "
+        "Keep the prompt concise and welcoming. Respond with JSON {{\"question_text\": string}}."
+    )
+
+    async def __call__(self, inp: IntroModuleInput) -> IntroModuleOutput:
+        role = inp.role or "open position"
+        candidate = inp.candidate_name or "candidate"
+        system_prompt = self.system_prompt_template.format(role=role, candidate=candidate)
+        data = await gateway.execute_task(
+            task_name="stage_1_intro",
+            system_prompt=system_prompt,
+        )
+        return IntroModuleOutput.model_validate(data)

--- a/services/orchestrator_service/programs/stage2_qa.py
+++ b/services/orchestrator_service/programs/stage2_qa.py
@@ -1,0 +1,102 @@
+"""DSPy program for Stage-2 focus area interview planning."""
+from __future__ import annotations
+
+from string import Template
+from typing import List
+
+import dspy
+from pydantic import BaseModel, Field
+
+from gateway_service import gateway
+from ..schemas import FocusAreaQuestions
+
+
+PROMPT_TEMPLATE = Template(
+    """You are an expert AI technical recruiter. Your task is to analyze the provided Job Description (JD) and Resume to create a structured interview question guide.
+
+Follow these instructions precisely:
+
+    Analyze and Synthesize: First, identify the key intersections between the JD's requirements (e.g., skills, responsibilities) and the candidate's experience (e.g., projects, roles).
+
+    Define Focus Areas: Based on your analysis, define 5 distinct and logical Focus Areas for a technical interview. Each Focus Area's name should be clear and concise (e.g., \"Productionization & MLOps,\" \"Modeling & Algorithms\").
+
+    Generate Questions: For each of the 5 Focus Areas, you must generate exactly 4 questions that are directly relevant to the JD and resume.
+
+    Adhere to Question Constraints:
+
+        Question Types: The 4 questions for each area must be categorized as:
+
+            2 reasoning questions: These should probe the \"why\" and \"how\" behind the candidate's decisions and experiences.
+
+            2 conceptual questions: These should test factual or definitional knowledge of tools and concepts mentioned.
+
+        Simplicity: All questions must be non-compound. Do not ask two things in one question.
+
+        Brevity: Each question must be concise, limited to a maximum of one or two lines.
+
+    Format Output as JSON: The final output must be a single, well-formed JSON object. Use the following structure:
+
+{
+  \"interview_focus_areas\": [
+    {
+      \"area_name\": \"Example: Project & Problem Formulation\",
+      \"reasoning_questions\": [
+        \"Question 1...\",
+        \"Question 2...\"
+      ],
+      \"conceptual_questions\": [
+        \"Question 1...\",
+        \"Question 2...\"
+      ]
+    },
+    {
+      \"area_name\": \"Focus Area 2 Name...\",
+      \"reasoning_questions\": [
+        \"...\",
+        \"...\"
+      ],
+      \"conceptual_questions\": [
+        \"...\",
+        \"...\"
+      ]
+    }
+  ]
+}
+
+[INSERT JOB DESCRIPTION HERE]
+
+$job_description
+
+[INSERT RESUME HERE]
+
+$resume
+"""
+)
+
+
+class Stage2QAInput(BaseModel):
+    """Inputs for generating focus areas and questions."""
+
+    jd_text: str = Field(default="", description="Raw job description text")
+    resume_text: str = Field(default="", description="Candidate resume text")
+
+
+class Stage2QAOutput(BaseModel):
+    """Structured focus areas returned by the LLM."""
+
+    interview_focus_areas: List[FocusAreaQuestions] = Field(default_factory=list)
+
+
+class Stage2QAProgram(dspy.Module):
+    """Request a focus-area driven interview plan from a dedicated LLM."""
+
+    async def __call__(self, inp: Stage2QAInput) -> Stage2QAOutput:
+        prompt = PROMPT_TEMPLATE.substitute(
+            job_description=inp.jd_text or "Not provided",
+            resume=inp.resume_text or "Not provided",
+        )
+        data = await gateway.execute_task(
+            task_name="stage_2_focus_plan",
+            system_prompt=prompt,
+        )
+        return Stage2QAOutput.model_validate(data)

--- a/services/orchestrator_service/schemas.py
+++ b/services/orchestrator_service/schemas.py
@@ -52,6 +52,23 @@ class InterviewBlueprintResponse(BaseModel):
     topics: List[TopicBlueprint]
 
 
+class FocusAreaQuestions(BaseModel):
+    """Grouped reasoning and conceptual questions for a focus area."""
+
+    area_name: str
+    reasoning_questions: List[str] = Field(default_factory=list)
+    conceptual_questions: List[str] = Field(default_factory=list)
+
+
+class FocusAreaExchange(BaseModel):
+    """Record of a single focus area question/answer pair."""
+
+    area_name: str
+    question_type: str
+    question_text: str
+    answer_text: Optional[str] = None
+
+
 class EvaluationRequest(BaseModel):
     """Request model for evaluating a candidate's answer."""
 
@@ -127,3 +144,5 @@ class ContextPacket(BaseModel):
     notes: List[str] = Field(default_factory=list)
     role_skill_tags: List[str] = Field(default_factory=list)
     experience_plan: List[str] = Field(default_factory=list)
+    focus_areas: List[FocusAreaQuestions] = Field(default_factory=list)
+    focus_area_history: List[FocusAreaExchange] = Field(default_factory=list)

--- a/services/session_service/interview_state.py
+++ b/services/session_service/interview_state.py
@@ -8,7 +8,7 @@ from orchestrator_service.schemas import ContextPacket
 class InterviewState:
     """Tracks the shared context packet and phase progression."""
 
-    phases: List[str] = ["theory", "wrap_up"]
+    phases: List[str] = ["intro", "qa", "theory", "wrap_up"]
     theory_steps: List[str] = [
         "primary",
         "followup",
@@ -29,6 +29,8 @@ class InterviewState:
         self.theory_index = 0
         self.theory_skill_index = 0
         self.wrapup_index = 0
+        self.qa_queue: List[dict] = []
+        self.qa_queue_index = 0
 
         # Metadata for logging
         self.session_id = session_id
@@ -38,6 +40,7 @@ class InterviewState:
         self.last_question_type: Optional[str] = None
         self.probed_followup_hooks: set[str] = set()
         self.last_followup_hook: Optional[str] = None
+        self.last_focus_area: Optional[str] = None
 
 
     @property
@@ -66,6 +69,40 @@ class InterviewState:
             )
             if self.theory_skill_index >= len(skills):
                 self.advance_phase()
+
+    def ensure_qa_queue(self, focus_areas: List) -> None:
+        """Populate the QA queue from the provided focus areas if empty."""
+
+        if self.qa_queue:
+            return
+
+        self.qa_queue_index = 0
+        queue: List[dict] = []
+        for area in focus_areas:
+            name = getattr(area, "area_name", "") or ""
+            if not name:
+                continue
+            reasoning = list(getattr(area, "reasoning_questions", []) or [])
+            conceptual = list(getattr(area, "conceptual_questions", []) or [])
+            for question in reasoning[:2]:
+                if question:
+                    queue.append(
+                        {
+                            "focus_area": name,
+                            "question_type": "reasoning",
+                            "text": question,
+                        }
+                    )
+            for question in conceptual[:2]:
+                if question:
+                    queue.append(
+                        {
+                            "focus_area": name,
+                            "question_type": "conceptual",
+                            "text": question,
+                        }
+                    )
+        self.qa_queue = queue
 
     @property
     def current_wrapup_step(self) -> str:

--- a/services/session_service/question_log_db.py
+++ b/services/session_service/question_log_db.py
@@ -24,6 +24,20 @@ def init_db(db_path: Path = DB_PATH) -> None:
         )
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS focus_area_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            candidate_id TEXT,
+            focus_area TEXT,
+            question_type TEXT,
+            question_text TEXT,
+            answer_text TEXT,
+            timestamp TEXT
+        )
+        """
+    )
     conn.commit()
     conn.close()
 
@@ -50,6 +64,39 @@ def log_question_response(
             session_id,
             candidate_id,
             stage,
+            question_type,
+            question_text,
+            answer_text,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def log_focus_area_response(
+    focus_area: str,
+    question_type: str,
+    question_text: str,
+    answer_text: str,
+    session_id: Optional[str] = None,
+    candidate_id: Optional[str] = None,
+    db_path: Path = DB_PATH,
+) -> None:
+    """Persist focus area question/answer data for later evaluation."""
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO focus_area_logs (
+            session_id, candidate_id, focus_area, question_type, question_text, answer_text, timestamp
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id,
+            candidate_id,
+            focus_area,
             question_type,
             question_text,
             answer_text,

--- a/services/session_service/service.py
+++ b/services/session_service/service.py
@@ -137,14 +137,17 @@ class ConnectionManager:
                         )
                 except Exception:
                     pass
+                payload = {
+                    "question_text": question,
+                    "stage": state.current_phase,
+                    "question_type": qtype,
+                }
+                if "focus_area" in q_payload:
+                    payload["focus_area"] = q_payload["focus_area"]
                 await websocket.send_json(
                     {
                         "event": "new_question",
-                        "payload": {
-                            "question_text": question,
-                            "stage": state.current_phase,
-                            "question_type": qtype,
-                        },
+                        "payload": payload,
                     }
                 )
             return
@@ -215,13 +218,16 @@ class ConnectionManager:
                     )
             except Exception:
                 pass
+            payload = {
+                "question_text": question,
+                "stage": state.current_phase,
+                "question_type": qtype,
+            }
+            if "focus_area" in q_payload:
+                payload["focus_area"] = q_payload["focus_area"]
             await websocket.send_json(
                 {
                     "event": "new_question",
-                    "payload": {
-                        "question_text": question,
-                        "stage": state.current_phase,
-                        "question_type": qtype,
-                    },
+                    "payload": payload,
                 }
             )

--- a/services/tests/test_end_to_end.py
+++ b/services/tests/test_end_to_end.py
@@ -24,7 +24,27 @@ async def test_run_interview_end_to_end(monkeypatch):
             }
         if task_name == "skill_tag_refinement":
             return {"tags": []}
+        if task_name == "stage_1_intro":
+            return {"question_text": "Welcome!"}
+        if task_name == "stage_2_focus_plan":
+            return {
+                "interview_focus_areas": [
+                    {
+                        "area_name": "Python Mastery",
+                        "reasoning_questions": [
+                            "Why do you enjoy Python?",
+                            "How have you optimized Python code?",
+                        ],
+                        "conceptual_questions": [
+                            "What is PEP 8?",
+                            "Explain the GIL.",
+                        ],
+                    }
+                ]
+            }
         if task_name == "stage_3_question":
+            if "previous answer" in system_prompt:
+                return {"question_text": "Follow-up on Python."}
             return {"question_text": "What is Python?"}
         if task_name == "stage_3_eval":
             return {"result": "pass", "rationale": "ok"}
@@ -41,18 +61,35 @@ async def test_run_interview_end_to_end(monkeypatch):
     orch = Orchestrator()
 
     q1 = await orch.loop(state)
-    assert q1["question_type"] == "theory_primary"
+    assert q1["question_type"] == "intro_greeting"
 
-    q2 = await orch.loop(state, "Answer")
-    assert q2["question_type"] == "theory_followup"
+    q2 = await orch.loop(state, "Intro answer")
+    assert q2["question_type"] == "qa_reasoning"
+    assert q2.get("focus_area") == "Python Mastery"
 
-    q3 = await orch.loop(state, "Answer2")
-    assert q3["question_type"] == "wrapup_feedback"
+    q3 = await orch.loop(state, "Reasoning 1")
+    assert q3["question_type"] == "qa_reasoning"
 
-    q4 = await orch.loop(state, "feedback")
-    assert q4["question_type"] == "wrapup_closing"
+    q4 = await orch.loop(state, "Reasoning 2")
+    assert q4["question_type"] == "qa_conceptual"
 
-    q5 = await orch.loop(state)
-    assert q5 is None
+    q5 = await orch.loop(state, "Conceptual 1")
+    assert q5["question_type"] == "qa_conceptual"
+
+    q6 = await orch.loop(state, "Conceptual 2")
+    assert q6["question_type"] == "theory_primary"
+
+    q7 = await orch.loop(state, "Theory answer")
+    assert q7["question_type"] == "theory_followup"
+
+    q8 = await orch.loop(state, "Theory followup")
+    assert q8["question_type"] == "wrapup_feedback"
+
+    q9 = await orch.loop(state, "feedback")
+    assert q9["question_type"] == "wrapup_closing"
+
+    q10 = await orch.loop(state)
+    assert q10 is None
+
     assert state.packet.time_remaining_min == 0
 

--- a/services/tests/test_flow.py
+++ b/services/tests/test_flow.py
@@ -20,6 +20,24 @@ async def test_run_interview_flow(monkeypatch):
                 "overlap_skills": ["python"],
                 "primary_overlap_focus": "python",
             }
+        if task_name == "stage_1_intro":
+            return {"question_text": "Welcome! Tell me about yourself."}
+        if task_name == "stage_2_focus_plan":
+            return {
+                "interview_focus_areas": [
+                    {
+                        "area_name": "Python Mastery",
+                        "reasoning_questions": [
+                            "Why do you enjoy working with Python?",
+                            "How have you improved a Python service?",
+                        ],
+                        "conceptual_questions": [
+                            "What is a virtual environment?",
+                            "Explain list comprehensions.",
+                        ],
+                    }
+                ]
+            }
         if task_name == "stage_3_question":
             if "python" in system_prompt:
                 return {"question_text": "What is Python?"}
@@ -39,6 +57,8 @@ async def test_run_interview_flow(monkeypatch):
     assert [v.skill for v in result.verifications] == ["python", "db"]
     assert call_order == [
         "stage_0_analysis",
+        "stage_1_intro",
+        "stage_2_focus_plan",
         "stage_3_question",
         "stage_3_eval",
         "stage_3_question",

--- a/services/tests/test_question_log_db.py
+++ b/services/tests/test_question_log_db.py
@@ -1,5 +1,9 @@
 import sqlite3
-from session_service.question_log_db import init_db, log_question_response
+from session_service.question_log_db import (
+    init_db,
+    log_question_response,
+    log_focus_area_response,
+)
 
 
 def test_log_question_response_captures_question_and_answer(tmp_path):
@@ -26,4 +30,31 @@ def test_log_question_response_captures_question_and_answer(tmp_path):
         "primary",
         "What is Python?",
         "A language",
+    )
+
+
+def test_log_focus_area_response_persists_focus_area(tmp_path):
+    db_path = tmp_path / "question_logs.db"
+    init_db(db_path)
+    log_focus_area_response(
+        focus_area="Python Mastery",
+        question_type="qa_reasoning",
+        question_text="Why did you choose Python?",
+        answer_text="Because of the ecosystem",
+        session_id="s1",
+        candidate_id="c1",
+        db_path=db_path,
+    )
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT focus_area, question_type, question_text, answer_text FROM focus_area_logs"
+    )
+    row = cur.fetchone()
+    conn.close()
+    assert row == (
+        "Python Mastery",
+        "qa_reasoning",
+        "Why did you choose Python?",
+        "Because of the ecosystem",
     )

--- a/services/tests/test_session_state.py
+++ b/services/tests/test_session_state.py
@@ -38,6 +38,10 @@ def test_stage_progression_and_time():
     packet = ContextPacket(jd_text="", resume_text="", duration_min=10)
     packet.time_remaining_min = 10
     state = InterviewState(packet)
+    assert state.current_phase == "intro"
+    state.advance_phase()
+    assert state.current_phase == "qa"
+    state.advance_phase()
     assert state.current_phase == "theory"
     state.advance_phase()
     assert state.current_phase == "wrap_up"


### PR DESCRIPTION
## Summary
- add DSPy stage modules for introductory greeting and focus-area QA planning
- extend orchestrator flow, context schema, and session state to run intro/QA phases and log focus-area answers
- persist focus-area turns in SQLite, surface focus area metadata to the client, and update tests for the new stages

## Testing
- pytest *(fails: missing fastapi, pydantic, httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a91dd32c8328bbb651ea142dfce0