### PR TITLE
Add rubric-based evaluation storage and aggregation

### DIFF
--- a/services/orchestrator_service/llm_api.py
+++ b/services/orchestrator_service/llm_api.py
@@ -1,7 +1,8 @@
 """Core AI interview utilities."""
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from types import SimpleNamespace
+from string import Template
 
 from .schemas import (
     InterviewRequest,
@@ -193,6 +194,103 @@ async def evaluate_candidate_answer(
     )
 
     return EvaluationResponse.model_validate(data)
+
+
+REASONING_EVAL_PROMPT = Template(
+    """You are an AI Interview Analyst 🧠. Your primary function is to evaluate a candidate's answer to a **reasoning-based** interview question using the multi-dimensional rubric provided below.\n\n**## Instructions:**\n1.  Carefully review the question, the candidate's resume context, and their verbatim answer.\n2.  For each of the 6 rubric dimensions, assign a score from 1 (poor) to 5 (excellent).\n3.  Calculate an `overall_score` by averaging the scores from all 6 dimensions.\n4.  Provide a concise justification for each dimensional score.\n5.  Format the final output as a single JSON object.\n\n**## Inputs:**\n* **QUESTION:** $question\n* **RESUME_CONTEXT:** $resume_context\n* **CANDIDATE_ANSWER:** $answer\n\n**## Output Format (JSON):**\n{\n  "evaluation_type": "Reasoning",\n  "overall_score": <Average of the 6 dimensional scores, rounded to two decimal places>,\n  "dimensional_scores": {\n    "problem_comprehension": {\n      "score": <1-5>,\n      "justification": "<Brief reason for this score>"\n    },\n    "structured_thinking": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "identification_of_assumptions": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "analysis_of_trade_offs": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "clarity_of_communication": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "conclusion_and_justification": {\n      "score": <1-5>,\n      "justification": "<...>"\n    }\n  }\n}\n"""
+)
+
+
+CONCEPTUAL_EVAL_PROMPT = Template(
+    """You are an AI Interview Analyst 📚. Your primary function is to evaluate a candidate's answer to a **conceptual/factual** interview question using the multi-dimensional rubric provided below.\n\n**## Instructions:**\n1.  Carefully review the question and the candidate's verbatim answer.\n2.  For each of the 5 rubric dimensions, assign a score from 1 (poor) to 5 (excellent).\n3.  Calculate an `overall_score` by averaging the scores from all 5 dimensions.\n4.  Provide a concise justification for each dimensional score.\n5.  Format the final output as a single JSON object.\n\n**## Inputs:**\n* **QUESTION:** $question\n* **CANDIDATE_ANSWER:** $answer\n\n**## Output Format (JSON):**\n{\n  "evaluation_type": "Conceptual",\n  "overall_score": <Average of the 5 dimensional scores, rounded to two decimal places>,\n  "dimensional_scores": {\n    "factual_accuracy": {\n      "score": <1-5>,\n      "justification": "<Brief reason for this score>"\n    },\n    "depth_of_knowledge": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "clarity_of_explanation": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "practical_application": {\n      "score": <1-5>,\n      "justification": "<...>"\n    },\n    "handling_of_nuance": {\n      "score": <1-5>,\n      "justification": "<...>"\n    }\n  }\n}\n"""
+)
+
+
+def _truncate_text(text: Optional[str], limit: int = 1800) -> str:
+    """Return ``text`` trimmed to ``limit`` characters for prompt hygiene."""
+
+    if not text:
+        return ""
+    stripped = str(text).strip()
+    if len(stripped) <= limit:
+        return stripped
+    return stripped[: limit - 3] + "..."
+
+
+async def _run_structured_evaluation(task_name: str, prompt: str) -> Dict[str, Any]:
+    """Execute a rubric-based evaluation prompt and ensure a dict is returned."""
+
+    data = await gateway.execute_task(task_name=task_name, system_prompt=prompt)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected dict response for {task_name}, received: {type(data)!r}")
+    return data
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        try:
+            return float(str(value).strip())
+        except (TypeError, ValueError):
+            return None
+
+
+def _normalize_dimensional_scores(raw: Any) -> Dict[str, Dict[str, Any]]:
+    """Ensure dimensional scores use floats and string justifications."""
+
+    result: Dict[str, Dict[str, Any]] = {}
+    if not isinstance(raw, dict):
+        return result
+    for name, payload in raw.items():
+        if not isinstance(payload, dict):
+            continue
+        score = _coerce_float(payload.get("score"))
+        justification = payload.get("justification")
+        result[str(name)] = {
+            "score": score,
+            "justification": "" if justification is None else str(justification),
+        }
+    return result
+
+
+async def evaluate_reasoning_response(
+    *, question: str, resume_context: str, answer: str
+) -> Dict[str, Any]:
+    """Run the reasoning rubric evaluation for a candidate response."""
+
+    prompt = REASONING_EVAL_PROMPT.substitute(
+        question=str(question).strip(),
+        resume_context=_truncate_text(resume_context),
+        answer=str(answer).strip(),
+    )
+    data = await _run_structured_evaluation("reasoning_evaluation", prompt)
+    data.setdefault("evaluation_type", "Reasoning")
+    overall = _coerce_float(data.get("overall_score"))
+    if overall is not None:
+        data["overall_score"] = overall
+    data["dimensional_scores"] = _normalize_dimensional_scores(
+        data.get("dimensional_scores")
+    )
+    return data
+
+
+async def evaluate_conceptual_response(*, question: str, answer: str) -> Dict[str, Any]:
+    """Run the conceptual rubric evaluation for a candidate response."""
+
+    prompt = CONCEPTUAL_EVAL_PROMPT.substitute(
+        question=str(question).strip(),
+        answer=str(answer).strip(),
+    )
+    data = await _run_structured_evaluation("conceptual_evaluation", prompt)
+    data.setdefault("evaluation_type", "Conceptual")
+    overall = _coerce_float(data.get("overall_score"))
+    if overall is not None:
+        data["overall_score"] = overall
+    data["dimensional_scores"] = _normalize_dimensional_scores(
+        data.get("dimensional_scores")
+    )
+    return data
 
 _interviewer = LLMInterviewer()
 _monitor = LLMMonitor()

--- a/services/orchestrator_service/orchestrator.py
+++ b/services/orchestrator_service/orchestrator.py
@@ -1,5 +1,6 @@
 """Stage-based orchestrator coordinating interview questions."""
 
+import logging
 from typing import Any, Optional
 
 from .llm_api import (
@@ -8,12 +9,17 @@ from .llm_api import (
     ensure_focus_area_plan,
     build_focus_area_question,
     record_focus_area_answer,
+    evaluate_reasoning_response,
+    evaluate_conceptual_response,
     # theory_primary_question,
     # theory_followup_question,
     wrapup_feedback,
 )
 from .followups import build_followup_question, update_followup_hooks
 from session_service.question_log_db import log_question_response, log_focus_area_response
+
+
+logger = logging.getLogger(__name__)
 
 
 class Orchestrator:
@@ -91,27 +97,53 @@ class Orchestrator:
 
         if phase == "qa":
             if answer is not None and getattr(state, "last_question_text", None):
+                evaluation_payload = None
+                last_qtype = getattr(state, "last_question_type", "") or ""
+                try:
+                    if last_qtype == "qa_reasoning":
+                        evaluation_payload = await evaluate_reasoning_response(
+                            question=getattr(state, "last_question_text", ""),
+                            resume_context=packet.resume_text or "",
+                            answer=answer,
+                        )
+                    elif last_qtype == "qa_conceptual":
+                        evaluation_payload = await evaluate_conceptual_response(
+                            question=getattr(state, "last_question_text", ""),
+                            answer=answer,
+                        )
+                except Exception:
+                    logger.exception(
+                        "Failed to evaluate %s answer for session %s",
+                        last_qtype,
+                        session_id,
+                    )
                 log_question_response(
                     stage=phase,
-                    question_type=getattr(state, "last_question_type", ""),
+                    question_type=last_qtype,
                     question_text=getattr(state, "last_question_text", ""),
                     answer_text=answer,
-                    session_id=getattr(state, "session_id", None),
-                    candidate_id=getattr(state, "candidate_id", None),
+                    session_id=session_id,
+                    job_id=job_id,
+                    resume_id=resume_id,
+                    candidate_id=candidate_id,
+                    evaluation=evaluation_payload,
                 )
                 if getattr(state, "last_focus_area", None):
                     log_focus_area_response(
                         focus_area=state.last_focus_area,
-                        question_type=getattr(state, "last_question_type", ""),
+                        question_type=last_qtype,
                         question_text=getattr(state, "last_question_text", ""),
                         answer_text=answer,
-                        session_id=getattr(state, "session_id", None),
-                        candidate_id=getattr(state, "candidate_id", None),
+                        session_id=session_id,
+                        job_id=job_id,
+                        resume_id=resume_id,
+                        candidate_id=candidate_id,
+                        evaluation=evaluation_payload,
                     )
                     record_focus_area_answer(
                         packet,
                         state.last_focus_area,
-                        getattr(state, "last_question_type", ""),
+                        last_qtype,
                         getattr(state, "last_question_text", ""),
                         answer,
                     )
@@ -165,61 +197,6 @@ class Orchestrator:
 
             state.advance_phase()
             return await self.decide_next_action(state, None)
-
-        if phase == "qa":
-            if answer is not None and getattr(state, "last_question_text", None):
-                log_question_response(
-                    stage=phase,
-                    question_type=getattr(state, "last_question_type", ""),
-                    question_text=getattr(state, "last_question_text", ""),
-                    answer_text=answer,
-                    session_id=session_id,
-                    job_id=job_id,
-                    resume_id=resume_id,
-                    candidate_id=candidate_id,
-                )
-                if getattr(state, "last_focus_area", None):
-                    log_focus_area_response(
-                        focus_area=state.last_focus_area,
-                        question_type=getattr(state, "last_question_type", ""),
-                        question_text=getattr(state, "last_question_text", ""),
-                        answer_text=answer,
-                        session_id=session_id,
-                        job_id=job_id,
-                        resume_id=resume_id,
-                        candidate_id=candidate_id,
-                    )
-                    record_focus_area_answer(
-                        packet,
-                        state.last_focus_area,
-                        getattr(state, "last_question_type", ""),
-                        getattr(state, "last_question_text", ""),
-                        answer,
-                    )
-                state.qa_queue_index += 1
-                state.last_question_text = None
-                state.last_question_type = None
-                state.last_focus_area = None
-
-            focus_areas = await ensure_focus_area_plan(packet)
-            state.ensure_qa_queue(focus_areas)
-
-            if state.qa_queue_index >= len(state.qa_queue):
-                state.advance_phase()
-                return await self.decide_next_action(state, None)
-
-            item = state.qa_queue[state.qa_queue_index]
-            q_payload = build_focus_area_question(
-                packet,
-                item["focus_area"],
-                item["question_type"],
-                item["text"],
-            )
-            state.last_question_text = q_payload.get("question_text")
-            state.last_question_type = q_payload.get("question_type")
-            state.last_focus_area = q_payload.get("focus_area")
-            return q_payload
-
 
         if phase == "wrap_up":
             if state.wrapup_index >= len(state.wrapup_steps):

--- a/services/session_service/question_log_db.py
+++ b/services/session_service/question_log_db.py
@@ -1,12 +1,13 @@
+import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any
 
 DB_PATH = Path(__file__).resolve().with_name("question_logs.db")
 
 
-def _ensure_columns(cur: sqlite3.Cursor, table: str, definitions: dict[str, str]) -> None:
+def _ensure_columns(cur: sqlite3.Cursor, table: str, definitions: Dict[str, str]) -> None:
     """Add any missing columns defined in ``definitions`` to ``table``."""
 
     cur.execute(f"PRAGMA table_info({table})")
@@ -14,6 +15,76 @@ def _ensure_columns(cur: sqlite3.Cursor, table: str, definitions: dict[str, str]
     for column, ddl in definitions.items():
         if column not in existing:
             cur.execute(f"ALTER TABLE {table} ADD COLUMN {ddl}")
+
+
+def _normalize_score(value: Optional[Any]) -> Optional[float]:
+    """Best-effort conversion of a score field to ``float``."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        try:
+            return float(str(value).strip())
+        except (TypeError, ValueError):
+            return None
+
+
+def _update_focus_area_average(
+    cur: sqlite3.Cursor, session_id: Optional[str], focus_area: Optional[str], score: Optional[float]
+) -> None:
+    """Update the running average score for a focus area within a session."""
+
+    if not session_id or not focus_area:
+        return
+    score_val = _normalize_score(score)
+    if score_val is None:
+        return
+    cur.execute(
+        """
+        INSERT INTO focus_area_averages (session_id, focus_area, total_score, sample_size, average_score)
+        VALUES (?, ?, ?, 1, ?)
+        ON CONFLICT(session_id, focus_area) DO UPDATE SET
+            total_score = focus_area_averages.total_score + excluded.total_score,
+            sample_size = focus_area_averages.sample_size + 1,
+            average_score = (focus_area_averages.total_score + excluded.total_score)
+                           / (focus_area_averages.sample_size + 1)
+        """,
+        (session_id, focus_area, score_val, score_val),
+    )
+
+
+def _update_dimension_averages(
+    cur: sqlite3.Cursor,
+    session_id: Optional[str],
+    evaluation_type: Optional[str],
+    dimensional_scores: Optional[Dict[str, Any]],
+) -> None:
+    """Maintain running averages for each rubric dimension per session."""
+
+    if not session_id or not evaluation_type or not isinstance(dimensional_scores, dict):
+        return
+    eval_type = str(evaluation_type)
+    for dimension, payload in dimensional_scores.items():
+        if not isinstance(payload, dict):
+            continue
+        score_val = _normalize_score(payload.get("score"))
+        if score_val is None:
+            continue
+        cur.execute(
+            """
+            INSERT INTO dimension_averages (
+                session_id, evaluation_type, dimension_name, total_score, sample_size, average_score
+            ) VALUES (?, ?, ?, ?, 1, ?)
+            ON CONFLICT(session_id, evaluation_type, dimension_name) DO UPDATE SET
+                total_score = dimension_averages.total_score + excluded.total_score,
+                sample_size = dimension_averages.sample_size + 1,
+                average_score = (dimension_averages.total_score + excluded.total_score)
+                               / (dimension_averages.sample_size + 1)
+            """,
+            (session_id, eval_type, str(dimension), score_val, score_val),
+        )
 
 
 def init_db(db_path: Path = DB_PATH) -> None:
@@ -33,12 +104,23 @@ def init_db(db_path: Path = DB_PATH) -> None:
             question_type TEXT,
             question_text TEXT,
             answer_text TEXT,
+            evaluation_type TEXT,
             evaluation_detail TEXT,
             evaluation_score REAL,
             timestamp TEXT
         )
         """
     )
+    _ensure_columns(
+        cur,
+        "question_logs",
+        {
+            "evaluation_type": "evaluation_type TEXT",
+            "evaluation_detail": "evaluation_detail TEXT",
+            "evaluation_score": "evaluation_score REAL",
+        },
+    )
+
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS focus_area_logs (
@@ -51,31 +133,56 @@ def init_db(db_path: Path = DB_PATH) -> None:
             question_type TEXT,
             question_text TEXT,
             answer_text TEXT,
+            evaluation_type TEXT,
             evaluation_detail TEXT,
             evaluation_score REAL,
             timestamp TEXT
         )
         """
     )
+    _ensure_columns(
+        cur,
+        "focus_area_logs",
+        {
+            "evaluation_type": "evaluation_type TEXT",
+            "evaluation_detail": "evaluation_detail TEXT",
+            "evaluation_score": "evaluation_score REAL",
+        },
+    )
+
     cur.execute(
         """
-        CREATE TABLE IF NOT EXISTS focus_area_logs (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
+        CREATE TABLE IF NOT EXISTS focus_area_averages (
             session_id TEXT,
-            candidate_id TEXT,
             focus_area TEXT,
-            question_type TEXT,
-            question_text TEXT,
-            answer_text TEXT,
-            timestamp TEXT
+            total_score REAL DEFAULT 0,
+            sample_size INTEGER DEFAULT 0,
+            average_score REAL DEFAULT 0,
+            PRIMARY KEY (session_id, focus_area)
         )
         """
     )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dimension_averages (
+            session_id TEXT,
+            evaluation_type TEXT,
+            dimension_name TEXT,
+            total_score REAL DEFAULT 0,
+            sample_size INTEGER DEFAULT 0,
+            average_score REAL DEFAULT 0,
+            PRIMARY KEY (session_id, evaluation_type, dimension_name)
+        )
+        """
+    )
+
     conn.commit()
     conn.close()
 
 
 def log_question_response(
+    *,
     stage: str,
     question_type: str,
     question_text: str,
@@ -86,9 +193,21 @@ def log_question_response(
     candidate_id: Optional[str] = None,
     evaluation_detail: Optional[str] = None,
     evaluation_score: Optional[float] = None,
+    evaluation: Optional[Dict[str, Any]] = None,
     db_path: Path = DB_PATH,
 ) -> None:
     """Persist a single question/answer pair to the log database."""
+
+    detail = evaluation_detail
+    score = evaluation_score
+    evaluation_type: Optional[str] = None
+    if isinstance(evaluation, dict):
+        evaluation_type = str(evaluation.get("evaluation_type") or "") or None
+        if detail is None:
+            detail = json.dumps(evaluation)
+        score = score if score is not None else _normalize_score(
+            evaluation.get("overall_score") or evaluation.get("score")
+        )
 
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
@@ -103,10 +222,11 @@ def log_question_response(
             question_type,
             question_text,
             answer_text,
+            evaluation_type,
             evaluation_detail,
             evaluation_score,
             timestamp
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             session_id,
@@ -117,8 +237,9 @@ def log_question_response(
             question_type,
             question_text,
             answer_text,
-            evaluation_detail,
-            evaluation_score,
+            evaluation_type,
+            detail,
+            score,
             datetime.now(UTC).isoformat(),
         ),
     )
@@ -127,6 +248,7 @@ def log_question_response(
 
 
 def log_focus_area_response(
+    *,
     focus_area: str,
     question_type: str,
     question_text: str,
@@ -137,9 +259,23 @@ def log_focus_area_response(
     candidate_id: Optional[str] = None,
     evaluation_detail: Optional[str] = None,
     evaluation_score: Optional[float] = None,
+    evaluation: Optional[Dict[str, Any]] = None,
     db_path: Path = DB_PATH,
 ) -> None:
     """Persist focus area question/answer data for later evaluation."""
+
+    detail = evaluation_detail
+    score = evaluation_score
+    evaluation_type: Optional[str] = None
+    dimensional_scores: Optional[Dict[str, Any]] = None
+    if isinstance(evaluation, dict):
+        evaluation_type = str(evaluation.get("evaluation_type") or "") or None
+        if detail is None:
+            detail = json.dumps(evaluation)
+        score = score if score is not None else _normalize_score(
+            evaluation.get("overall_score") or evaluation.get("score")
+        )
+        dimensional_scores = evaluation.get("dimensional_scores")
 
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
@@ -154,10 +290,11 @@ def log_focus_area_response(
             question_type,
             question_text,
             answer_text,
+            evaluation_type,
             evaluation_detail,
             evaluation_score,
             timestamp
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             session_id,
@@ -168,77 +305,17 @@ def log_focus_area_response(
             question_type,
             question_text,
             answer_text,
-            evaluation_detail,
-            evaluation_score,
+            evaluation_type,
+            detail,
+            score,
             datetime.now(UTC).isoformat(),
         ),
     )
-    conn.commit()
-    conn.close()
 
+    if evaluation_type:
+        _update_dimension_averages(cur, session_id, evaluation_type, dimensional_scores)
+    _update_focus_area_average(cur, session_id, focus_area, score)
 
-def log_focus_area_response(
-    focus_area: str,
-    question_type: str,
-    question_text: str,
-    answer_text: str,
-    session_id: Optional[str] = None,
-    candidate_id: Optional[str] = None,
-    db_path: Path = DB_PATH,
-) -> None:
-    """Persist focus area question/answer data for later evaluation."""
-
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        INSERT INTO focus_area_logs (
-            session_id, candidate_id, focus_area, question_type, question_text, answer_text, timestamp
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            session_id,
-            candidate_id,
-            focus_area,
-            question_type,
-            question_text,
-            answer_text,
-            datetime.now(UTC).isoformat(),
-        ),
-    )
-    conn.commit()
-    conn.close()
-
-
-def log_focus_area_response(
-    focus_area: str,
-    question_type: str,
-    question_text: str,
-    answer_text: str,
-    session_id: Optional[str] = None,
-    candidate_id: Optional[str] = None,
-    db_path: Path = DB_PATH,
-) -> None:
-    """Persist focus area question/answer data for later evaluation."""
-
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        INSERT INTO focus_area_logs (
-            session_id, candidate_id, focus_area, question_type, question_text, answer_text, timestamp
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            session_id,
-            candidate_id,
-            focus_area,
-            question_type,
-            question_text,
-            answer_text,
-            datetime.now(UTC).isoformat(),
-        ),
-    )
     conn.commit()
     conn.close()
 

--- a/services/tests/test_llm_api.py
+++ b/services/tests/test_llm_api.py
@@ -125,6 +125,55 @@ async def test_evaluate_candidate_answer(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reasoning_evaluation_prompt(monkeypatch):
+    async def fake_execute(task_name, system_prompt, user_prompt=None):
+        assert task_name == "reasoning_evaluation"
+        assert "QUESTION:" in system_prompt
+        assert "RESUME_CONTEXT" in system_prompt
+        return {
+            "evaluation_type": "Reasoning",
+            "overall_score": "4.5",
+            "dimensional_scores": {
+                "problem_comprehension": {
+                    "score": "5",
+                    "justification": "Clear"
+                }
+            },
+        }
+
+    monkeypatch.setattr(ai.gateway, "execute_task", fake_execute)
+
+    result = await ai.evaluate_reasoning_response(
+        question="Explain scaling", resume_context="Built services", answer="Used autoscaling"
+    )
+    assert result["evaluation_type"] == "Reasoning"
+    assert result["overall_score"] == 4.5
+    assert result["dimensional_scores"]["problem_comprehension"]["score"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_conceptual_evaluation_prompt(monkeypatch):
+    async def fake_execute(task_name, system_prompt, user_prompt=None):
+        assert task_name == "conceptual_evaluation"
+        assert "QUESTION:" in system_prompt
+        return {
+            "overall_score": 3,
+            "dimensional_scores": {
+                "factual_accuracy": {"score": 3, "justification": "OK"}
+            },
+        }
+
+    monkeypatch.setattr(ai.gateway, "execute_task", fake_execute)
+
+    result = await ai.evaluate_conceptual_response(
+        question="What is a DAG?", answer="Directed acyclic graph"
+    )
+    assert result["evaluation_type"] == "Conceptual"
+    assert result["overall_score"] == 3.0
+    assert result["dimensional_scores"]["factual_accuracy"]["score"] == 3.0
+
+
+@pytest.mark.asyncio
 async def test_generate_introductory_question(monkeypatch):
     async def fake_execute(task_name, system_prompt, user_prompt=None):
         assert task_name == "question_generation"

--- a/services/tests/test_question_log_db.py
+++ b/services/tests/test_question_log_db.py
@@ -1,4 +1,8 @@
+import json
 import sqlite3
+
+import pytest
+
 from session_service.question_log_db import (
     init_db,
     log_question_response,
@@ -9,6 +13,13 @@ from session_service.question_log_db import (
 def test_log_question_response_captures_question_and_answer(tmp_path):
     db_path = tmp_path / "question_logs.db"
     init_db(db_path)
+    evaluation_payload = {
+        "evaluation_type": "Reasoning",
+        "overall_score": 4.25,
+        "dimensional_scores": {
+            "problem_comprehension": {"score": 4, "justification": "Understood"}
+        },
+    }
     log_question_response(
         stage="theory",
         question_type="primary",
@@ -18,8 +29,7 @@ def test_log_question_response_captures_question_and_answer(tmp_path):
         job_id="job-42",
         resume_id="resume-99",
         candidate_id="c1",
-        evaluation_detail="Strong fundamentals",
-        evaluation_score=8.5,
+        evaluation=evaluation_payload,
         db_path=db_path,
     )
     conn = sqlite3.connect(db_path)
@@ -33,6 +43,7 @@ def test_log_question_response_captures_question_and_answer(tmp_path):
             answer_text,
             job_id,
             resume_id,
+            evaluation_type,
             evaluation_detail,
             evaluation_score
         FROM question_logs
@@ -40,36 +51,116 @@ def test_log_question_response_captures_question_and_answer(tmp_path):
     )
     row = cur.fetchone()
     conn.close()
-    assert row == (
+    assert row[:6] == (
         "theory",
         "primary",
         "What is Python?",
         "A language",
+        "job-42",
+        "resume-99",
     )
+    assert row[6] == "Reasoning"
+    stored_detail = json.loads(row[7])
+    assert pytest.approx(stored_detail["overall_score"], rel=1e-6) == 4.25
+    assert pytest.approx(row[8], rel=1e-6) == 4.25
 
 
-def test_log_focus_area_response_persists_focus_area(tmp_path):
+def test_focus_area_logs_store_evaluations_and_averages(tmp_path):
     db_path = tmp_path / "question_logs.db"
     init_db(db_path)
+    reasoning_eval = {
+        "evaluation_type": "Reasoning",
+        "overall_score": 4.0,
+        "dimensional_scores": {
+            "problem_comprehension": {"score": 5, "justification": "Great"},
+            "analysis_of_trade_offs": {"score": 3, "justification": "Average"},
+        },
+    }
+    conceptual_eval = {
+        "evaluation_type": "Conceptual",
+        "overall_score": 3.0,
+        "dimensional_scores": {
+            "factual_accuracy": {"score": 2, "justification": "Partial"},
+            "clarity_of_explanation": {"score": 4, "justification": "Clear"},
+        },
+    }
     log_focus_area_response(
         focus_area="Python Mastery",
         question_type="qa_reasoning",
         question_text="Why did you choose Python?",
         answer_text="Because of the ecosystem",
         session_id="s1",
+        job_id="job-42",
+        resume_id="resume-99",
         candidate_id="c1",
+        evaluation=reasoning_eval,
         db_path=db_path,
     )
+    log_focus_area_response(
+        focus_area="Python Mastery",
+        question_type="qa_conceptual",
+        question_text="What is a Python decorator?",
+        answer_text="It wraps a function",
+        session_id="s1",
+        job_id="job-42",
+        resume_id="resume-99",
+        candidate_id="c1",
+        evaluation=conceptual_eval,
+        db_path=db_path,
+    )
+
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     cur.execute(
-        "SELECT focus_area, question_type, question_text, answer_text FROM focus_area_logs"
+        """
+        SELECT focus_area, question_type, evaluation_type, evaluation_score
+        FROM focus_area_logs
+        ORDER BY id
+        """
     )
-    row = cur.fetchone()
+    rows = cur.fetchall()
+    assert rows[0] == ("Python Mastery", "qa_reasoning", "Reasoning", pytest.approx(4.0))
+    assert rows[1] == ("Python Mastery", "qa_conceptual", "Conceptual", pytest.approx(3.0))
+
+    cur.execute(
+        """
+        SELECT total_score, sample_size, average_score
+        FROM focus_area_averages
+        WHERE session_id = ? AND focus_area = ?
+        """,
+        ("s1", "Python Mastery"),
+    )
+    total_score, sample_size, average_score = cur.fetchone()
+    assert pytest.approx(total_score, rel=1e-6) == 7.0
+    assert sample_size == 2
+    assert pytest.approx(average_score, rel=1e-6) == 3.5
+
+    cur.execute(
+        """
+        SELECT evaluation_type, dimension_name, average_score, sample_size
+        FROM dimension_averages
+        WHERE session_id = ?
+        ORDER BY evaluation_type, dimension_name
+        """,
+        ("s1",),
+    )
+    dim_rows = cur.fetchall()
+    reasoning_dims = {
+        (etype, name): (avg, count)
+        for etype, name, avg, count in dim_rows
+        if etype == "Reasoning"
+    }
+    conceptual_dims = {
+        (etype, name): (avg, count)
+        for etype, name, avg, count in dim_rows
+        if etype == "Conceptual"
+    }
+    assert reasoning_dims[("Reasoning", "problem_comprehension")] == (
+        pytest.approx(5.0),
+        1,
+    )
+    assert conceptual_dims[("Conceptual", "factual_accuracy")] == (
+        pytest.approx(2.0),
+        1,
+    )
     conn.close()
-    assert row == (
-        "Python Mastery",
-        "qa_reasoning",
-        "Why did you choose Python?",
-        "Because of the ecosystem",
-    )


### PR DESCRIPTION
## Summary
- add rubric-specific evaluation helpers for reasoning and conceptual answers and invoke them from the orchestrator
- persist LLM evaluation payloads with per-session focus area and dimension averages in the session database
- expand unit tests to cover the new evaluation normalization and aggregation behaviour

## Testing
- pytest *(fails: missing optional dependencies such as fastapi/pydantic/httpx in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cce769c883288498acf79ad70057