### PR TITLE
Handle list outputs for primary overlap focus

### DIFF
--- a/services/orchestrator_service/programs/stage0_analysis.py
+++ b/services/orchestrator_service/programs/stage0_analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 import dspy
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from gateway_service import gateway
 
@@ -26,6 +26,23 @@ class JDResumeAnalysisOutput(BaseModel):
     primary_overlap_focus: Optional[str] = None
     selected_project: Optional[str] = None
     experience_plan: List[str] = Field(default_factory=list)
+
+    @field_validator("primary_overlap_focus", mode="before")
+    @classmethod
+    def _coerce_primary_overlap_focus(cls, value: object) -> Optional[str]:
+        """Normalize LLM output to a single descriptive string."""
+
+        if value is None or isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            cleaned_values = [
+                str(item).strip()
+                for item in value
+                if item is not None and str(item).strip()
+            ]
+            return ", ".join(cleaned_values) if cleaned_values else None
+        coerced = str(value).strip()
+        return coerced or None
 
 
 class Stage0AnalysisProgram(dspy.Module):

--- a/services/tests/test_stage0_analysis.py
+++ b/services/tests/test_stage0_analysis.py
@@ -1,0 +1,35 @@
+from orchestrator_service.programs.stage0_analysis import JDResumeAnalysisOutput
+
+
+def test_primary_overlap_focus_accepts_list():
+    raw_output = {
+        "role_from_jd": "backend",
+        "jd_core_skills": ["python"],
+        "resume_claims": ["python"],
+        "overlap_skills": ["python"],
+        "primary_overlap_focus": [
+            "Python + SQL driven data pipelines",
+            "Time-series modeling",
+        ],
+    }
+
+    parsed = JDResumeAnalysisOutput.model_validate(raw_output)
+
+    assert (
+        parsed.primary_overlap_focus
+        == "Python + SQL driven data pipelines, Time-series modeling"
+    )
+
+
+def test_primary_overlap_focus_handles_empty_list():
+    raw_output = {
+        "role_from_jd": "backend",
+        "jd_core_skills": ["python"],
+        "resume_claims": ["python"],
+        "overlap_skills": ["python"],
+        "primary_overlap_focus": [],
+    }
+
+    parsed = JDResumeAnalysisOutput.model_validate(raw_output)
+
+    assert parsed.primary_overlap_focus is None


### PR DESCRIPTION
## Summary
- normalize the `primary_overlap_focus` field returned by the stage 0 analysis program so list outputs are coerced into a readable string
- add regression tests that confirm list and empty list values are accepted during validation

## Testing
- pytest *(fails: missing fastapi and pydantic dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e474ca048328a3d059438845a182