### PR TITLE
Remove Gemini configuration from gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run the service with Docker Compose:
    cp services/gateway_service/.env.example services/gateway_service/.env
    ```
 
-   Update `services/gateway_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_MODEL`, `GEMINI_API_KEY`, and `LOCAL_LLM_URL`.
+   Update `services/gateway_service/.env` with real values for `LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_MODEL`, and `LOCAL_LLM_URL`.
 
    When using an LLM running on your host machine (e.g., LM Studio), set
    `LLM_PROVIDER=local` and point `LOCAL_LLM_URL` to the host using

--- a/services/gateway_service/.env.example
+++ b/services/gateway_service/.env.example
@@ -1,7 +1,6 @@
 LLM_PROVIDER=local
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo
-GEMINI_API_KEY=
 LOCAL_LLM_URL=http://host.docker.internal:1234/v1/chat/completions
 
 # Logging / tracing

--- a/services/gateway_service/ai_gateway.py
+++ b/services/gateway_service/ai_gateway.py
@@ -19,9 +19,6 @@ from json_repair import repair_json
 from .config import settings
 
 
-GEMINI_PROVIDER_NAMES = {"gemini", "google_gemini", "google", "google_studio", "google-studio"}
-
-
 class AIGateway:
     """Singleton gateway managing HTTP clients for LLM providers."""
 
@@ -55,12 +52,6 @@ class AIGateway:
                 "base_url": "https://api.openai.com/v1/chat/completions",
                 "api_key": settings.openai_api_key or None,
                 "model": settings.openai_model,
-            }
-        if name in GEMINI_PROVIDER_NAMES:
-            return {
-                "base_url": settings.gemini_api_url,
-                "api_key": settings.gemini_api_key or None,
-                "model": settings.gemini_model,
             }
         if name in {"auto_answer", "auto-answer", "autoanswer"}:
             return {
@@ -99,24 +90,15 @@ class AIGateway:
         if not url or not model:
             raise RuntimeError(f"Provider '{provider_name}' missing url/model configuration")
 
-        is_gemini = self._is_gemini_provider(provider_name)
         headers: Dict[str, str] = {}
-        if is_gemini:
-            if not api_key:
-                raise RuntimeError("Gemini provider requires an API key for health check")
-            headers["x-goog-api-key"] = api_key
-        elif api_key:
+        if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
         messages: list[Dict[str, str]] = [
             {"role": "system", "content": "healthcheck"},
             {"role": "user", "content": "ping"},
         ]
-        if is_gemini:
-            payload = self._build_gemini_payload(messages, {})
-            url = self._build_gemini_endpoint(url, model)
-        else:
-            payload = {"model": model, "messages": messages}
+        payload = {"model": model, "messages": messages}
 
         client = self._get_client(provider_name)
         timeout = httpx.Timeout(connect=connect_timeout, read=read_timeout, write=read_timeout, pool=read_timeout)
@@ -179,8 +161,6 @@ class AIGateway:
         if not url or not model:
             raise ValueError(f"Provider '{provider_name}' missing required configuration (url/model)")
 
-        is_gemini = self._is_gemini_provider(provider_name)
-
         messages = [{"role": "system", "content": system_prompt}]
         if user_prompt:
             messages.append({"role": "user", "content": user_prompt})
@@ -194,36 +174,20 @@ class AIGateway:
                 option_overrides[key] = task_cfg.get(key)
             elif isinstance(provider_cfg.get(key), (int, float, str, list, dict)) and key not in option_overrides:
                 option_overrides[key] = provider_cfg.get(key)
-            if not is_gemini and key in option_overrides:
+            if key in option_overrides:
                 payload[key] = option_overrides[key]
 
         headers: Dict[str, str] = {}
-        if is_gemini:
-            if not api_key:
-                raise ValueError("Gemini provider requires an API key")
-            headers["x-goog-api-key"] = api_key
-            request_json = self._build_gemini_payload(messages, option_overrides)
-            request_url = self._build_gemini_endpoint(url, model)
-        else:
-            if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
-            request_json = payload
-            request_url = url
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        request_json = payload
+        request_url = url
 
         client = self._get_client(provider_name)
         # No per-request timeout for LLM calls (disabled by request)
         response = await client.post(request_url, headers=headers, json=request_json)
         response.raise_for_status()
         raw = response.json()
-
-        if is_gemini:
-            gemini_text = self._extract_gemini_text(raw)
-            if gemini_text:
-                raw = {
-                    "choices": [
-                        {"message": {"role": "assistant", "content": gemini_text}}
-                    ]
-                }
 
         # Try to normalize OpenAI-style chat completion output into the
         # JSON object requested by callers. If we cannot parse a JSON object
@@ -290,134 +254,6 @@ class AIGateway:
             + "': "
             + content[:500]
         )
-
-    @staticmethod
-    def _is_gemini_provider(name: str) -> bool:
-        return isinstance(name, str) and name in GEMINI_PROVIDER_NAMES
-
-    @staticmethod
-    def _build_gemini_endpoint(base_url: Optional[str], model: Optional[str]) -> str:
-        if not base_url or not isinstance(base_url, str):
-            raise ValueError("Gemini provider requires a base_url")
-        if not model:
-            raise ValueError("Gemini provider requires a model")
-        base = base_url.rstrip("/")
-        if not base:
-            raise ValueError("Gemini provider requires a base_url")
-        if ":generate" in base:
-            return base
-        if base.endswith(model):
-            return base if base.endswith(":generateContent") else f"{base}:generateContent"
-        if base.endswith("/models"):
-            return f"{base}/{model}:generateContent"
-        return f"{base}/{model}:generateContent"
-
-    @staticmethod
-    def _build_gemini_payload(messages: list[Dict[str, Any]], overrides: Dict[str, Any]) -> Dict[str, Any]:
-        contents: list[Dict[str, Any]] = []
-        system_prompts: list[str] = []
-        for msg in messages:
-            if not isinstance(msg, dict):
-                continue
-            text = msg.get("content")
-            if not isinstance(text, str):
-                continue
-            cleaned = text.strip()
-            if not cleaned:
-                continue
-            role = (msg.get("role") or "user").lower()
-            if role == "system":
-                system_prompts.append(cleaned)
-                continue
-            gemini_role = "model" if role == "assistant" else "user"
-            contents.append({"role": gemini_role, "parts": [{"text": cleaned}]})
-
-        if not contents and system_prompts:
-            contents.append({"role": "user", "parts": [{"text": "\n\n".join(system_prompts)}]})
-            system_prompts = []
-
-        if not contents:
-            raise ValueError("Gemini request requires at least one message")
-
-        payload: Dict[str, Any] = {"contents": contents}
-        if system_prompts:
-            payload["system_instruction"] = {
-                "role": "system",
-                "parts": [{"text": "\n\n".join(system_prompts)}],
-            }
-
-        generation_config: Dict[str, Any] = {}
-        temperature = overrides.get("temperature")
-        if isinstance(temperature, (int, float)):
-            generation_config["temperature"] = float(temperature)
-        top_p = overrides.get("top_p")
-        if isinstance(top_p, (int, float)):
-            generation_config["topP"] = float(top_p)
-        max_tokens = overrides.get("max_tokens")
-        if isinstance(max_tokens, (int, float)):
-            generation_config["maxOutputTokens"] = int(max_tokens)
-        stops = overrides.get("stop")
-        if isinstance(stops, str) and stops:
-            generation_config["stopSequences"] = [stops]
-        elif isinstance(stops, list):
-            cleaned_stops = [str(item) for item in stops if isinstance(item, (str, int, float))]
-            if cleaned_stops:
-                generation_config["stopSequences"] = cleaned_stops
-        candidate_count = overrides.get("n")
-        if isinstance(candidate_count, (int, float)) and int(candidate_count) > 0:
-            generation_config["candidateCount"] = int(candidate_count)
-        if generation_config:
-            payload["generationConfig"] = generation_config
-
-        response_format = overrides.get("response_format")
-        if isinstance(response_format, dict):
-            fmt = response_format.get("type")
-            if isinstance(fmt, str) and fmt.lower() == "json_object":
-                payload["responseMimeType"] = "application/json"
-        elif isinstance(response_format, str) and response_format.lower() == "json_object":
-            payload["responseMimeType"] = "application/json"
-
-        return payload
-
-    @staticmethod
-    def _extract_gemini_text(raw: Any) -> Optional[str]:
-        if not isinstance(raw, dict):
-            return None
-
-        candidates = raw.get("candidates")
-        if not isinstance(candidates, list):
-            return None
-
-        def _collect_text(obj: Any) -> list[str]:
-            texts: list[str] = []
-            if isinstance(obj, dict):
-                text_val = obj.get("text")
-                if isinstance(text_val, str):
-                    texts.append(text_val)
-                parts = obj.get("parts")
-                if isinstance(parts, list):
-                    for part in parts:
-                        texts.extend(_collect_text(part))
-            elif isinstance(obj, list):
-                for item in obj:
-                    texts.extend(_collect_text(item))
-            elif isinstance(obj, str):
-                texts.append(obj)
-            return texts
-
-        for cand in candidates:
-            if not isinstance(cand, dict):
-                continue
-            texts = _collect_text(cand.get("content"))
-            # Some responses expose text directly on the candidate
-            direct = cand.get("text")
-            if isinstance(direct, str):
-                texts.append(direct)
-            merged = "\n".join(t.strip() for t in texts if isinstance(t, str) and t.strip())
-            if merged:
-                return merged
-
-        return None
 
     @staticmethod
     def _parse_json_like(text: str) -> Any:

--- a/services/gateway_service/config.py
+++ b/services/gateway_service/config.py
@@ -56,12 +56,6 @@ class Settings:
     # Model identifier for local OpenAI-compatible servers
     # Prefer llm_router_config.yml, allow env override
     local_model: str = os.getenv("LOCAL_LLM_MODEL", _LOCAL_MODEL_YAML)
-    gemini_api_key: str = os.getenv("GEMINI_API_KEY", "")
-    gemini_model: str = os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
-    gemini_api_url: str = os.getenv(
-        "GEMINI_API_URL",
-        "https://generativelanguage.googleapis.com/v1/models",
-    )
     # Local OpenAI-compatible server URL; prefer llm_router_config.yml, allow env override
     local_llm_url: str = os.getenv("LOCAL_LLM_URL", _LOCAL_BASE_URL_YAML)
     # Dedicated provider configuration for the auto-answer generator

--- a/services/gateway_service/llm_router_config.yml
+++ b/services/gateway_service/llm_router_config.yml
@@ -30,11 +30,6 @@ providers:
     model: dpo-qwen2-1.5b-instruct-human-like
     temperature: 0.8
 
-  # Google AI Studio Gemini provider (uses generateContent endpoint)
-  gemini:
-    base_url: https://generativelanguage.googleapis.com/v1/models
-    model: gemini-2.5-flash
-
   # Optional: keep OpenAI config for fallback/manual switching
   # openai:
   #   base_url: https://api.openai.com/v1/chat/completions
@@ -49,7 +44,7 @@ tasks:
   answer_evaluation:
     provider: local
   auto_answer_generation:
-    provider: gemini
+    provider: local
   # Heavier tasks used by the app-test endpoints
   fake_candidate_profile:
     provider: local


### PR DESCRIPTION
## Summary
- remove Gemini-specific provider defaults and helper methods from the AI gateway
- drop the Gemini provider entry from the router config and env example, routing auto-answer generation back to the local provider
- update the README to reflect the remaining environment variables

## Testing
- python3 -m compileall services/gateway_service

------
https://chatgpt.com/codex/tasks/task_e_68c93aa13a688328ab284a874047c638